### PR TITLE
feature: add support for persistant UDFs and UDF references

### DIFF
--- a/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
@@ -533,6 +533,22 @@ class BigQueryClient[F[_]](
           }
         }
     }
+
+  def getRoutine(udfId: UDF.UDFId.PersistentId): F[Option[Routine]] =
+    F.interruptible {
+      val routineId = RoutineId.of(udfId.dataset.project.value, udfId.dataset.id, udfId.name.value)
+      Option(bigQuery.getRoutine(routineId)).filter(_.exists())
+    }
+
+  def create(info: RoutineInfo): F[Routine] =
+    F.delay(bigQuery.create(info))
+
+  def update(info: RoutineInfo): F[Routine] =
+    F.delay(bigQuery.update(info))
+
+  def delete(udfId: UDF.UDFId.PersistentId): F[Boolean] =
+    F.delay(bigQuery.delete(RoutineId.of(udfId.dataset.project.value, udfId.dataset.id, udfId.name.value)))
+
 }
 
 object BigQueryClient {

--- a/core/src/main/scala/no/nrk/bigquery/internal/UdfUpdateOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/UdfUpdateOperation.scala
@@ -1,0 +1,101 @@
+package no.nrk.bigquery.internal
+
+import com.google.cloud.bigquery.{Option => _, _}
+import no.nrk.bigquery.UDF.Body
+import no.nrk.bigquery.{BQType, UDF, UdfOperationMeta, UpdateOperation}
+
+import scala.jdk.CollectionConverters._
+
+object UdfUpdateOperation {
+
+  private val UdfRoutineType = "SCALAR_FUNCTION"
+
+  def from(
+      udf: UDF.Persistent,
+      maybeExisting: Option[RoutineInfo]
+  ): UpdateOperation = maybeExisting match {
+    case None =>
+      UpdateOperation.CreatePersistentUdf(udf, createRoutineInfo(udf))
+    case Some(value) =>
+      val recreated = recreateRoutine(value)
+      val routineFromUdf = createRoutineInfo(udf)
+      if (value.getRoutineType != UdfRoutineType)
+        UpdateOperation.Illegal(UdfOperationMeta(value, udf), s"Routine type ${value.getRoutineType} not supported")
+      else if (recreated == routineFromUdf) UpdateOperation.Noop(UdfOperationMeta(value, udf))
+      else UpdateOperation.UpdatePersistentUdf(udf, routineFromUdf)
+  }
+
+  private def createRoutineInfo(udf: UDF.Persistent) = {
+    val baseBuilder = RoutineInfo
+      .newBuilder(toRoutineId(udf.name))
+      .setRoutineType(UdfRoutineType)
+      .setArguments(udf.params.map(toRoutineArgs).asJava)
+      .setReturnType(udf.returnType.map(toSqlDataType).orNull)
+
+    (udf.body match {
+      case Body.Sql(body) =>
+        baseBuilder
+          .setLanguage("SQL")
+          .setBody(body.asString)
+      case Body.Js(javascriptSnippet, gsLibraryPath) =>
+        baseBuilder
+          .setLanguage("JAVASCRIPT")
+          .setBody(javascriptSnippet)
+          .setImportedLibraries(gsLibraryPath.asJava)
+    }).build()
+  }
+
+  private def recreateRoutine(r: RoutineInfo) =
+    RoutineInfo
+      .newBuilder(r.getRoutineId)
+      .setRoutineType(UdfRoutineType)
+      .setArguments(r.getArguments)
+      .setReturnType(r.getReturnType)
+      .setLanguage(r.getLanguage)
+      .setBody(r.getBody)
+      .setImportedLibraries(r.getImportedLibraries)
+      .build()
+
+  private def toRoutineId(udfId: UDF.UDFId.PersistentId) =
+    RoutineId.of(udfId.dataset.project.value, udfId.dataset.id, udfId.name.value)
+
+  private def toRoutineArgs(param: UDF.Param): RoutineArgument =
+    param.maybeType match {
+      case Some(value) =>
+        RoutineArgument
+          .newBuilder()
+          .setName(param.name.value)
+          .setDataType(toSqlDataType(value))
+          .build()
+      case None =>
+        RoutineArgument
+          .newBuilder()
+          .setName(param.name.value)
+          .setKind("ANY_TYPE")
+          .build()
+    }
+
+  private def toSqlDataType(bqType: BQType): StandardSQLDataType = {
+    val dataType =
+      if (bqType.tpe == StandardSQLTypeName.STRUCT)
+        StandardSQLDataType
+          .newBuilder()
+          .setStructType(
+            StandardSQLStructType
+              .newBuilder()
+              .setFields(bqType.subFields.map { case (name, fieldBqType) =>
+                StandardSQLField.newBuilder(name, toSqlDataType(fieldBqType)).build()
+              }.asJava)
+              .build())
+          .build()
+      else StandardSQLDataType.newBuilder().setTypeKind(bqType.tpe.name()).build()
+
+    if (bqType.mode == Field.Mode.REPEATED)
+      StandardSQLDataType
+        .newBuilder()
+        .setTypeKind(StandardSQLTypeName.ARRAY.name())
+        .setArrayElementType(dataType)
+        .build()
+    else dataType
+  }
+}

--- a/core/src/test/scala/no/nrk/bigquery/UDFTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/UDFTest.scala
@@ -7,24 +7,30 @@ class UDFTest extends FunSuite {
 
   test("render temporary SQL UDF") {
     assertEquals(
-      UDF(
-        ident"foo",
-        List(UDF.Param("n", BQType.FLOAT64)),
-        UDF.Body.Sql(bqfr"""(n + 1)"""),
-        Some(BQType.FLOAT64)
-      ).definition.asString,
+      UDF
+        .temporary(
+          ident"foo",
+          List(UDF.Param("n", BQType.FLOAT64)),
+          UDF.Body.Sql(bqfr"""(n + 1)"""),
+          Some(BQType.FLOAT64)
+        )
+        .definition
+        .asString,
       """CREATE TEMP FUNCTION foo(n FLOAT64) RETURNS FLOAT64 AS ((n + 1));"""
     )
   }
 
   test("render temporary javascript UDF") {
     assertEquals(
-      UDF(
-        ident"foo",
-        List(UDF.Param("n", BQType.FLOAT64)),
-        UDF.Body.Js("return n + 1", List.empty),
-        Some(BQType.FLOAT64)
-      ).definition.asString,
+      UDF
+        .temporary(
+          ident"foo",
+          List(UDF.Param("n", BQType.FLOAT64)),
+          UDF.Body.Js("return n + 1", List.empty),
+          Some(BQType.FLOAT64)
+        )
+        .definition
+        .asString,
       """|CREATE TEMP FUNCTION foo(n FLOAT64) RETURNS FLOAT64 LANGUAGE js AS '''
          |return n + 1
          |''';""".stripMargin
@@ -33,17 +39,55 @@ class UDFTest extends FunSuite {
 
   test("render temporary javascript UDF with library path") {
     assertEquals(
-      UDF(
-        ident"foo",
-        List(UDF.Param("n", BQType.FLOAT64)),
-        UDF.Body.Js("return n + 1", List("bucket/foo.js")),
-        Some(BQType.FLOAT64)
-      ).definition.asString,
+      UDF
+        .temporary(
+          ident"foo",
+          List(UDF.Param("n", BQType.FLOAT64)),
+          UDF.Body.Js("return n + 1", List("bucket/foo.js")),
+          Some(BQType.FLOAT64)
+        )
+        .definition
+        .asString,
       """|CREATE TEMP FUNCTION foo(n FLOAT64) RETURNS FLOAT64 LANGUAGE js AS '''
          |return n + 1
          |'''
          |OPTIONS ( library=["gs://bucket/foo.js"] );""".stripMargin
     )
+  }
+
+  test("render temporary udf call") {
+    val udf = UDF
+      .temporary(
+        ident"fnName",
+        List(UDF.Param("n", BQType.FLOAT64)),
+        UDF.Body.Js("return n + 1", List("bucket/foo.js")),
+        Some(BQType.FLOAT64)
+      )
+    assertEquals(bqfr"${udf(1d)}".asString, "fnName(1.0)")
+  }
+
+  test("render persistent call") {
+    val udf = UDF
+      .persistent(
+        ident"fnName",
+        BQDataset(ProjectId("p1"), "ds1", None),
+        List(UDF.Param("n", BQType.FLOAT64)),
+        UDF.Body.Js("return n + 1", List("bucket/foo.js")),
+        Some(BQType.FLOAT64)
+      )
+
+    assertEquals(bqfr"${udf(1d)}".asString, "`p1.ds1.fnName`(1.0)")
+  }
+
+  test("render udf ref call") {
+    val udf = UDF.reference(
+      ident"fnName",
+      BQDataset(ProjectId("p1"), "ds1", None),
+      List(UDF.Param("n", BQType.FLOAT64)),
+      Some(BQType.FLOAT64)
+    )
+
+    assertEquals(bqfr"${udf(1d)}".asString, "`p1.ds1.fnName`(1.0)")
   }
 
 }

--- a/core/src/test/scala/no/nrk/bigquery/internal/UdfUpdateOperationTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/internal/UdfUpdateOperationTest.scala
@@ -1,0 +1,57 @@
+package no.nrk.bigquery.internal
+
+import com.google.cloud.bigquery.{RoutineId, RoutineInfo}
+import munit.FunSuite
+import no.nrk.bigquery.UpdateOperation.{CreatePersistentUdf, Illegal, UpdatePersistentUdf}
+import no.nrk.bigquery._
+import no.nrk.bigquery.syntax._
+
+class UdfUpdateOperationTest extends FunSuite {
+
+  private val udf =
+    UDF.persistent(
+      ident"foo",
+      BQDataset(ProjectId("p1"), "ds1", None),
+      Nil,
+      UDF.Body.Sql(bqfr"(1)"),
+      Some(BQType.INT64))
+  private val routineId: RoutineId = RoutineId.of("p1", "ds1", "foo")
+
+  test("should create when it does not exist") {
+    UdfUpdateOperation.from(udf, None) match {
+      case CreatePersistentUdf(_, routine) =>
+        assertEquals(routine.getRoutineId, routineId)
+      case other => fail(other.toString)
+    }
+  }
+
+  test("should update udf when changed") {
+    val existingRoutine = UdfUpdateOperation.from(udf, None) match {
+      case CreatePersistentUdf(_, routine) => routine
+      case other => fail(s"test setup failed: ${other.toString}")
+    }
+
+    UdfUpdateOperation.from(
+      udf.copy(params = UDF.Param(ident"foo", Some(BQType.INT64)) :: Nil),
+      Some(existingRoutine)
+    ) match {
+      case UpdatePersistentUdf(newUdf, newRoutine) =>
+        assertNotEquals(newUdf, udf)
+        assertNotEquals(newRoutine, existingRoutine)
+      case other => fail(other.toString)
+    }
+  }
+
+  test("should not attempt to update non udf routine types") {
+    val routine = RoutineInfo
+      .newBuilder(routineId)
+      .setRoutineType("PROCEDURE")
+      .build()
+
+    UdfUpdateOperation.from(udf, Some(routine)) match {
+      case Illegal(_, _) =>
+      case other => fail(other.toString)
+    }
+  }
+
+}

--- a/docs/example_view.md
+++ b/docs/example_view.md
@@ -47,8 +47,8 @@ object Schemas {
       BQPartitionType.NotPartitioned
     )
 
-    val fullNameUdf: UDF = UDF(
-      Ident("toFullName"),
+    val fullNameUdf: UDF.Temporary = UDF.temporary(
+      ident"toFullName",
       UDF.Param.fromField(namesStruct) :: Nil,
       UDF.Body.Sql(
         bqfr"""(names.firstName || ' ' || coalesce(names.middleName || ' ', '') || names.lastName)""".stripMargin
@@ -103,8 +103,9 @@ object UserEventView {
   )
 
 }
-
 ```
+
+Note: Use `EnsureUpdated` to deploy the view to BiqQuery
 
 ## Testing
 

--- a/testing/src/main/scala/no/nrk/bigquery/testing/BQStructuredSql.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/BQStructuredSql.scala
@@ -1,6 +1,7 @@
 package no.nrk.bigquery.testing
 
 import com.google.cloud.bigquery.UserDefinedFunction
+import no.nrk.bigquery.UDF.Temporary
 import no.nrk.bigquery._
 
 import scala.collection.mutable
@@ -58,7 +59,8 @@ object BQStructuredSql {
     val querySegmentList = split.last
 
     val functions: List[UserDefinedFunction] = {
-      val fs1 = fullQuery.allReferencedUDFs.map(udf => UserDefinedFunction.inline(udf.definition.asString))
+      val fs1 = fullQuery.allReferencedUDFs
+        .collect { case udf: Temporary => UserDefinedFunction.inline(udf.definition.asString) }
       val fs2 = functionSegmentLists.map(segmentList => UserDefinedFunction.inline(segmentList.asString + ";"))
       fs1.toList ++ fs2
     }


### PR DESCRIPTION
Add support for 
- persistent UDF with deployment
- reference "external" UDF

This is a breaking change. The UDF class has been split into three types, persistent, temporary and reference.