### PR TITLE
BQFrag.collect is traversing too deep

### DIFF
--- a/core/src/main/scala/no/nrk/bigquery/BQSqlFrag.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQSqlFrag.scala
@@ -79,7 +79,7 @@ sealed trait BQSqlFrag {
         case BQSqlFrag.Call(_, args) => args
         case BQSqlFrag.Combined(values) => values.toList
         case BQSqlFrag.PartitionRef(_) => Nil
-        case BQSqlFrag.FillRef(fill) => fill.query :: Nil
+        case BQSqlFrag.FillRef(_) => Nil
         case BQSqlFrag.FilledTableRef(_) => Nil
       }
 

--- a/core/src/test/scala/no/nrk/bigquery/BQSqlFragTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQSqlFragTest.scala
@@ -100,7 +100,7 @@ class BQSqlFragTest extends FunSuite {
       .collect { case BQSqlFrag.Call(udf, _) => udf }
       .map(_.name)
 
-    assertEquals(udfIdents, outerUdf2.name :: Nil)
+    assertEquals(udfIdents, outerUdf1.name :: Nil)
   }
 
   def mkTable(name: String) = {


### PR DESCRIPTION
We should not traverse into `BQFill` by default