### PR TITLE
fix: check fields by name when we do not require an index check

### DIFF
--- a/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
@@ -39,15 +39,17 @@ object TableUpdateOperation {
                 )
 
                 val illegalSchemaExtension: Option[UpdateOperation.IllegalSchemaExtension] =
-                  conforms(
-                    actualSchema = remoteAsTableDef.schema,
-                    givenSchema = localTableDef.schema
-                  ).map { reasons =>
-                    UpdateOperation.IllegalSchemaExtension(
-                      TableDefOperationMeta(existingRemoteTable, tableDef),
-                      reasons.mkString(", ")
+                  conforms
+                    .onlyTypes(
+                      actualSchema = remoteAsTableDef.schema,
+                      givenSchema = localTableDef.schema
                     )
-                  }
+                    .map { reasons =>
+                      UpdateOperation.IllegalSchemaExtension(
+                        TableDefOperationMeta(existingRemoteTable, tableDef),
+                        reasons.mkString(", ")
+                      )
+                    }
 
                 if (localTableDef == remoteAsTableDef)
                   UpdateOperation.Noop(TableDefOperationMeta(existingRemoteTable, localTableDef))

--- a/core/src/test/scala/no/nrk/bigquery/conformsTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/conformsTest.scala
@@ -1,0 +1,63 @@
+package no.nrk.bigquery
+
+import com.google.cloud.bigquery.{Field, StandardSQLTypeName}
+import munit.FunSuite
+
+class conformsTest extends FunSuite {
+  test("failing conform by type position") {
+    val violations = conforms.onlyTypes(
+      BQSchema.of(
+        BQField("one", StandardSQLTypeName.STRING, Field.Mode.NULLABLE),
+        BQField("two", StandardSQLTypeName.INT64, Field.Mode.NULLABLE)
+      ),
+      BQSchema.of(
+        BQField("one", StandardSQLTypeName.INT64, Field.Mode.NULLABLE),
+        BQField("two", StandardSQLTypeName.STRING, Field.Mode.NULLABLE)
+      )
+    )
+    assertEquals(violations.map(_.length), Some(2), clue(violations.map(_.mkString(", "))))
+  }
+
+  test("passing conform by type position") {
+    val violations = conforms.onlyTypes(
+      BQSchema.of(
+        BQField("one", StandardSQLTypeName.STRING, Field.Mode.NULLABLE),
+        BQField("two", StandardSQLTypeName.INT64, Field.Mode.NULLABLE)
+      ),
+      BQSchema.of(
+        BQField("one", StandardSQLTypeName.STRING, Field.Mode.NULLABLE),
+        BQField("two", StandardSQLTypeName.INT64, Field.Mode.NULLABLE)
+      )
+    )
+    assertEquals(violations.map(_.length), None, clue(violations.map(_.mkString(", "))))
+  }
+
+  test("passing conform by name and type") {
+    val violations = conforms.typesAndName(
+      BQSchema.of(
+        BQField("one", StandardSQLTypeName.STRING, Field.Mode.NULLABLE),
+        BQField("two", StandardSQLTypeName.INT64, Field.Mode.NULLABLE)
+      ),
+      BQSchema.of(
+        BQField("two", StandardSQLTypeName.INT64, Field.Mode.NULLABLE),
+        BQField("one", StandardSQLTypeName.STRING, Field.Mode.NULLABLE)
+      )
+    )
+    assertEquals(violations.map(_.length), None, clue(violations.map(_.mkString(", "))))
+  }
+
+  test("failing conform by name and type") {
+    val violations = conforms.typesAndName(
+      BQSchema.of(
+        BQField("one", StandardSQLTypeName.STRING, Field.Mode.NULLABLE),
+        BQField("two", StandardSQLTypeName.INT64, Field.Mode.NULLABLE)
+      ),
+      BQSchema.of(
+        BQField("two", StandardSQLTypeName.STRING, Field.Mode.NULLABLE),
+        BQField("one", StandardSQLTypeName.INT64, Field.Mode.NULLABLE)
+      )
+    )
+    assertEquals(violations.map(_.length), Some(2), clue(violations.map(_.mkString(", "))))
+  }
+
+}

--- a/testing/src/main/scala/no/nrk/bigquery/testing/BQSmokeTest.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/BQSmokeTest.scala
@@ -291,7 +291,7 @@ object BQSmokeTest {
     def checkSchema(actualSchema: BQSchema): Unit =
       this match {
         case CheckType.Schema(expectedSchema) =>
-          conforms(actualSchema, expectedSchema) match {
+          conforms.onlyTypes(actualSchema, expectedSchema) match {
             case Some(reasons) =>
               fail(s"Failed because ${reasons.mkString(", ")}", TypeClue(expectedSchema, actualSchema))
             case None => assert(true)


### PR DESCRIPTION
In some cases we do not care about the order of the fields as long as the name and type matches.

I bumped into this issue when I did rewrite some structs using `BqSqlProjection` where the fields in the structs did not match the order in the schema. The smoke-test (`bqCheckFragmentTest`) failed with a index/type error.