### PR TITLE
Fix/table location diff

### DIFF
--- a/core/src/main/scala/no/nrk/bigquery/LocationId.scala
+++ b/core/src/main/scala/no/nrk/bigquery/LocationId.scala
@@ -10,8 +10,8 @@ final case class LocationId private[bigquery] (value: String) extends AnyVal
 
 object LocationId {
   // Multi region
-  val US = LocationId("us")
-  val EU = LocationId("eu")
+  val US = LocationId("US")
+  val EU = LocationId("EU")
 
   // Americas
   val NorthAmericaNorthEast1 = LocationId("northamerica-northeast1")

--- a/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
@@ -38,7 +38,7 @@ object SchemaHelper {
           typ <- PartitionTypeHelper.from(st).left.map(msg => TableConversionError.UnsupportedPartitionType(msg))
           tableId <- parsedId
         } yield BQTableDef.Table(
-          tableId = tableId,
+          tableId = tableId.withLocation(Some(LocationId(st.getLocation))),
           schema = fromSchema(st.getSchema),
           partitionType = typ,
           description = Option(table.getDescription),

--- a/core/src/test/scala/no/nrk/bigquery/internal/TableUpdateOperationTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/internal/TableUpdateOperationTest.scala
@@ -402,7 +402,7 @@ class TableUpdateOperationTest extends FunSuite {
       TableLabels.Empty,
       tableOptions = TableOptions(partitionFilterRequired = filter)
     )
-    def remote(filter: Boolean) = Some(
+    def remote(filter: Option[Boolean]) = Some(
       TableInfo
         .newBuilder(
           tableId.underlying,
@@ -416,25 +416,28 @@ class TableUpdateOperationTest extends FunSuite {
             )
             .build()
         )
-        .setRequirePartitionFilter(filter)
+        .setRequirePartitionFilter(filter.map(Boolean.box).orNull)
         .build()
     )
 
-    TableUpdateOperation.from(testTable(true), remote(false)) match {
+    TableUpdateOperation.from(testTable(true), remote(Some(false))) match {
       case UpdateOperation.UpdateTable(_, _, table) =>
         assert(table.getRequirePartitionFilter)
       case other => fail(other.toString)
     }
-    TableUpdateOperation.from(testTable(false), remote(true)) match {
+    TableUpdateOperation.from(testTable(false), remote(Some(true))) match {
       case UpdateOperation.UpdateTable(_, _, table) =>
         assert(!table.getRequirePartitionFilter)
       case other => fail(other.toString)
     }
-    TableUpdateOperation.from(testTable(true), remote(true)) match {
+    TableUpdateOperation.from(testTable(true), remote(Some(true))) match {
       case UpdateOperation.Noop(_) =>
       case other => fail(other.toString)
     }
-
+    TableUpdateOperation.from(testTable(false), remote(None)) match {
+      case UpdateOperation.Noop(_) =>
+      case other => fail(other.toString)
+    }
   }
 
 }


### PR DESCRIPTION
Location isn't handled properly when we diff remote and local tables and views. This results in all our tables and views will always be marked as needed to be updated.



Reworked, using cats `Eq`. ~I'm not a fan of overriding hashCode and equals in BQDataset. The alternative can be to enforce a location but that has it's own issues (for instance when we parse a reference).~