### PR TITLE
PartitionLoader.unpartitioned should not crash on empty table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.tools.mima.core._
 
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.11" // your current series x.y
+ThisBuild / tlBaseVersion := "0.12" // your current series x.y
 
 ThisBuild / organization := "no.nrk.bigquery"
 ThisBuild / organizationName := "NRK"

--- a/core/src/main/scala/no/nrk/bigquery/BQTableLike.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQTableLike.scala
@@ -62,7 +62,7 @@ object BQTableLike {
 
     def loadPartition[F[_]: Concurrent](
         client: BigQueryClient[F]
-    ): F[(BQPartitionId[Unit], PartitionMetadata)] =
+    ): F[Option[(BQPartitionId[Unit], PartitionMetadata)]] =
       PartitionLoader.unpartitioned(table, client).widen
   }
 }

--- a/core/src/main/scala/no/nrk/bigquery/PartitionLoader.scala
+++ b/core/src/main/scala/no/nrk/bigquery/PartitionLoader.scala
@@ -53,7 +53,7 @@ private[bigquery] object PartitionLoader {
       case notPartitioned: BQPartitionType.NotPartitioned =>
         PartitionLoader
           .unpartitioned(table.withTableType[Unit](notPartitioned), client)
-          .map(Vector(_))
+          .map(_.toVector)
     }
 
   case class LongInstant(value: Instant)
@@ -312,7 +312,7 @@ private[bigquery] object PartitionLoader {
         client: BigQueryClient[F]
     )(implicit
         F: Concurrent[F]
-    ): F[(BQPartitionId.NotPartitioned, PartitionMetadata)] =
+    ): F[Option[(BQPartitionId.NotPartitioned, PartitionMetadata)]] =
       client
         .synchronousQuery(
           BQJobName.auto,
@@ -330,7 +330,7 @@ private[bigquery] object PartitionLoader {
           (partition, metadata)
         }
         .compile
-        .lastOrError
+        .last
 
     def partitionQuery(tableId: BQTableId): BQQuery[
       (Option[LongInstant], Option[LongInstant], Option[Long], Option[Long])

--- a/core/src/main/scala/no/nrk/bigquery/TableOps.scala
+++ b/core/src/main/scala/no/nrk/bigquery/TableOps.scala
@@ -105,7 +105,7 @@ object TableOps {
     ): F[Vector[(BQPartitionId[Unit], PartitionMetadata)]] =
       table.partitionType match {
         case _: BQPartitionType.NotPartitioned =>
-          PartitionLoader.unpartitioned(table, client).map(Vector(_)).widen
+          PartitionLoader.unpartitioned(table, client).map(_.toVector).widen
       }
   }
 }


### PR DESCRIPTION
lastOrError produces as NoSuchElementException

This is a binary breaking change, and requires version bump.