### PR TITLE
override config from service credentials

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,9 @@ lazy val core = crossProject(JVMPlatform)
     Compile / doc / scalacOptions ++= Seq(
       "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
     ),
-    mimaBinaryIssueFilters := Nil
+    mimaBinaryIssueFilters := List(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("no.nrk.bigquery.BigQueryClient.fromCredentials")
+    )
   )
 
 lazy val prometheus = crossProject(JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -109,9 +109,7 @@ lazy val core = crossProject(JVMPlatform)
     Compile / doc / scalacOptions ++= Seq(
       "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
     ),
-    mimaBinaryIssueFilters := List(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("no.nrk.bigquery.BigQueryClient.fromCredentials")
-    )
+    mimaBinaryIssueFilters := Nil
   )
 
 lazy val prometheus = crossProject(JVMPlatform)
@@ -169,7 +167,6 @@ lazy val codegen = crossProject(JVMPlatform)
     libraryDependencies ++= Seq(
       "org.apache.commons" % "commons-text" % "1.11.0"
     ),
-    tlMimaPreviousVersions := Set.empty,
     mimaBinaryIssueFilters := Nil
   )
 

--- a/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
@@ -612,6 +612,12 @@ object BigQueryClient {
 
   def fromCredentials[F[_]](
       credentials: Credentials,
+      configure: Option[BigQueryOptions.Builder => BigQueryOptions.Builder]
+  )(implicit F: Async[F]): F[BigQuery] =
+    fromCredentials(credentials, configure)
+
+  def fromCredentials[F[_]](
+      credentials: Credentials,
       configure: Option[BigQueryOptions.Builder => BigQueryOptions.Builder] = None,
       clientDefaults: Option[BQClientDefaults] = None
   )(implicit F: Async[F]): F[BigQuery] =

--- a/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
@@ -614,7 +614,7 @@ object BigQueryClient {
       credentials: Credentials,
       configure: Option[BigQueryOptions.Builder => BigQueryOptions.Builder]
   )(implicit F: Async[F]): F[BigQuery] =
-    fromCredentials(credentials, configure)
+    fromCredentials(credentials, configure, None)
 
   def fromCredentials[F[_]](
       credentials: Credentials,


### PR DESCRIPTION
Binary Compatible

Client defaults should be the way to configure billing and default job project.