### PR TITLE
fix: generate cacheable smoketest for tvf

### DIFF
--- a/testing/src/main/scala/no/nrk/bigquery/testing/BQSmokeTest.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/BQSmokeTest.scala
@@ -449,7 +449,7 @@ object BQSmokeTest {
         val schemaOpt: Option[BQSchema] =
           pid.wholeTable match {
             case BQTableRef(_, _, _) => None
-            case _: BQAppliedTableValuedFunction[Any] => None
+            case x: BQAppliedTableValuedFunction[Any] => Some(x.schema)
             case x: BQTableDef[Any] => Some(x.schema)
           }
 


### PR DESCRIPTION
This fixes an issue where we do not generate CTE during tests for tvf because we did not know the schema.