### PR TITLE
Dataset reference

### DIFF
--- a/core/src/main/scala/no/nrk/bigquery/BQDataset.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQDataset.scala
@@ -26,6 +26,8 @@ final case class BQDataset private[bigquery] (
   def withoutLocation: BQDataset = copy(location = None)
   def withId(id: String): BQDataset = copy(id = id)
   def withProject(project: ProjectId): BQDataset = copy(project = project)
+
+  def toRef: BQDataset.Ref = BQDataset.Ref(project, id)
 }
 
 object BQDataset {
@@ -37,4 +39,6 @@ object BQDataset {
   def of(project: ProjectId, dataset: String, location: Option[LocationId] = None): Either[String, BQDataset] =
     if (regex.matcher(dataset).matches()) Right(BQDataset(project, dataset, location))
     else Left(s"invalid project ID '$dataset' - must match ${regex.pattern()}")
+
+  final case class Ref private[bigquery] (project: ProjectId, id: String)
 }

--- a/core/src/main/scala/no/nrk/bigquery/BQRoutine.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQRoutine.scala
@@ -26,7 +26,7 @@ sealed trait BQPersistentRoutine[N <: Nat, C] extends BQRoutine[N, C] {
 
 object BQPersistentRoutine {
   trait Id {
-    def dataset: BQDataset
+    def dataset: BQDataset.Ref
     def name: Ident
     def asString: String
   }
@@ -70,7 +70,7 @@ case class TVF[+P, N <: Nat](
 }
 
 object TVF {
-  case class TVFId(dataset: BQDataset, name: Ident) extends BQPersistentRoutine.Id {
+  case class TVFId(dataset: BQDataset.Ref, name: Ident) extends BQPersistentRoutine.Id {
     override def asString: String = show"${dataset.project.value}.${dataset.id}.$name"
     def asFragment: BQSqlFrag = BQSqlFrag.backticks(asString)
   }
@@ -162,7 +162,7 @@ object UDF {
 
   def persistent[N <: Nat](
       name: Ident,
-      dataset: BQDataset,
+      dataset: BQDataset.Ref,
       params: BQRoutine.Params[N],
       body: UDF.Body,
       returnType: Option[BQType]
@@ -171,7 +171,7 @@ object UDF {
 
   def reference[N <: Nat](
       name: Ident,
-      dataset: BQDataset,
+      dataset: BQDataset.Ref,
       params: BQRoutine.Params[N],
       returnType: Option[BQType]
   ): Reference[N] =
@@ -192,7 +192,7 @@ object UDF {
       implicit val bqShows: BQShow[TemporaryId] = _.asFragment
     }
 
-    case class PersistentId(dataset: BQDataset, name: Ident) extends UDFId with BQPersistentRoutine.Id {
+    case class PersistentId(dataset: BQDataset.Ref, name: Ident) extends UDFId with BQPersistentRoutine.Id {
       override def asString: String = show"${dataset.project.value}.${dataset.id}.$name"
       override def asFragment: BQSqlFrag = BQSqlFrag.backticks(asString)
     }

--- a/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
@@ -366,7 +366,7 @@ class BigQueryClient[F[_]](
     .delay {
       // a copy of `table` with new coordinates
       table.copy(tableId = BQTableId(
-        tmpDataset,
+        tmpDataset.toRef,
         table.tableId.tableName + UUID.randomUUID().toString
       ))
     }
@@ -566,7 +566,7 @@ class BigQueryClient[F[_]](
         .asScala
         .toVector
         .parTraverseFilter { table =>
-          val tableId = unsafeTableIdFromGoogle(dataset, table.getTableId)
+          val tableId = unsafeTableIdFromGoogle(dataset.toRef, table.getTableId)
           table.getDefinition[TableDefinition] match {
             case definition: StandardTableDefinition =>
               PartitionTypeHelper.from(definition) match {

--- a/core/src/main/scala/no/nrk/bigquery/internal/ConversionSyntax.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/ConversionSyntax.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.internal
+
+import no.nrk.bigquery.BQDataset
+
+trait ConversionSyntax {
+  implicit def toBQDatasetRef(ds: BQDataset): BQDataset.Ref = ds.toRef
+}

--- a/core/src/main/scala/no/nrk/bigquery/internal/GoogleTypeHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/GoogleTypeHelper.scala
@@ -32,7 +32,7 @@ object GoogleTypeHelper {
     }
   )
 
-  def unsafeTableIdFromGoogle(dataset: BQDataset, tableId: TableId): BQTableId = {
+  def unsafeTableIdFromGoogle(dataset: BQDataset.Ref, tableId: TableId): BQTableId = {
     require(
       tableId.getProject == dataset.project.value && dataset.id == tableId.getDataset,
       s"Expected google table Id($tableId) to be the same datasetId and project as provided dataset[$dataset]"

--- a/core/src/main/scala/no/nrk/bigquery/internal/GoogleTypeHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/GoogleTypeHelper.scala
@@ -17,7 +17,7 @@ import scala.jdk.CollectionConverters._
 
 object GoogleTypeHelper {
 
-  def toDatasetGoogle(ds: BQDataset): DatasetId = DatasetId.of(ds.project.value, ds.id)
+  def toDatasetGoogle(ds: BQDataset.Ref): DatasetId = DatasetId.of(ds.project.value, ds.id)
   def toTableIdGoogle(tableId: BQTableId): TableId =
     TableId.of(tableId.dataset.project.value, tableId.dataset.id, tableId.tableName)
 
@@ -45,6 +45,10 @@ object GoogleTypeHelper {
   }
 
   implicit class BQDatasetOps(val ds: BQDataset) extends AnyVal {
+    def underlying: DatasetId = toDatasetGoogle(ds.toRef)
+  }
+
+  implicit class BQDatasetRefOps(val ds: BQDataset.Ref) extends AnyVal {
     def underlying: DatasetId = toDatasetGoogle(ds)
   }
 

--- a/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
@@ -38,7 +38,7 @@ object SchemaHelper {
           typ <- PartitionTypeHelper.from(st).left.map(msg => TableConversionError.UnsupportedPartitionType(msg))
           tableId <- parsedId
         } yield BQTableDef.Table(
-          tableId = tableId.withLocation(Some(LocationId(st.getLocation))),
+          tableId = tableId,
           schema = fromSchema(st.getSchema),
           partitionType = typ,
           description = Option(table.getDescription),

--- a/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
@@ -16,18 +16,8 @@ import cats.syntax.all._
 
 object TableUpdateOperation {
 
-  private implicit val tableIdEquality: Eq[BQTableId] = Eq.instance { (a, b) =>
-    ((a.dataset.location, b.dataset.location) match {
-      case (Some(aLoc), Some(bLoc)) => aLoc == bLoc
-      case _ => true
-    }) &&
-    a.dataset.project == b.dataset.project &&
-    a.dataset.id == b.dataset.id &&
-    a.tableName == b.tableName
-
-  }
   private implicit val tableDefEquality: Eq[BQTableDef.Table[Any]] = Eq.instance { (a, b) =>
-    a.tableId === b.tableId &&
+    a.tableId == b.tableId &&
     a.schema == b.schema &&
     a.partitionType == b.partitionType &&
     a.clustering == b.clustering &&
@@ -37,7 +27,7 @@ object TableUpdateOperation {
   }
 
   private implicit val viewDefEquality: Eq[BQTableDef.View[Any]] = Eq.instance { (a, b) =>
-    a.tableId === b.tableId &&
+    a.tableId == b.tableId &&
     a.schema == b.schema &&
     a.partitionType == b.partitionType &&
     a.query == b.query &&
@@ -46,7 +36,7 @@ object TableUpdateOperation {
   }
 
   private implicit val materializedViewDefEquality: Eq[BQTableDef.MaterializedView[Any]] = Eq.instance { (a, b) =>
-    a.tableId === b.tableId &&
+    a.tableId == b.tableId &&
     a.schema == b.schema &&
     a.partitionType == b.partitionType &&
     a.query == b.query &&

--- a/core/src/main/scala/no/nrk/bigquery/syntax.scala
+++ b/core/src/main/scala/no/nrk/bigquery/syntax.scala
@@ -6,6 +6,6 @@
 
 package no.nrk.bigquery
 
-import no.nrk.bigquery.internal.{BQLiteralSyntax, BQShowSyntax}
+import no.nrk.bigquery.internal.{BQLiteralSyntax, BQShowSyntax, ConversionSyntax}
 
-object syntax extends BQLiteralSyntax with BQShowSyntax
+object syntax extends BQLiteralSyntax with BQShowSyntax with ConversionSyntax

--- a/core/src/test/scala/no/nrk/bigquery/BQFillTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQFillTest.scala
@@ -14,7 +14,7 @@ import java.time.LocalDate
 class BQFillTest extends FunSuite {
   case class JobKey(value: String) extends JobKeyBQ
 
-  private def tableId(name: String) = BQTableId(BQDataset(ProjectId("p1"), "d1", None), name)
+  private def tableId(name: String) = BQTableId(BQDataset.Ref(ProjectId("p1"), "d1"), name)
 
   private val c1 = BQField("c1", BQField.Type.DATE, BQField.Mode.REQUIRED)
   private val source1: BQTableDef.Table[LocalDate] =

--- a/core/src/test/scala/no/nrk/bigquery/BQSqlFragTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQSqlFragTest.scala
@@ -66,7 +66,7 @@ class BQSqlFragTest extends FunSuite {
 
   test("collect partitions in order") {
     val date = LocalDate.of(2023, 1, 1)
-    def tableId(name: String) = BQTableId(BQDataset(ProjectId("p1"), "d1", None), name)
+    def tableId(name: String) = BQTableId(BQDataset.Ref(ProjectId("p1"), "d1"), name)
 
     val t1 = BQTableRef(tableId("t1"), DatePartitioned(Ident("column1")))
     val t2 = BQTableRef(tableId("t2"), DatePartitioned(Ident("column1")))
@@ -120,7 +120,7 @@ class BQSqlFragTest extends FunSuite {
     val partitionField = BQField("partitionDate", BQField.Type.DATE, BQField.Mode.REQUIRED)
 
     BQTableDef.Table(
-      BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("foo"), "bar"), name),
+      BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("foo"), "bar").toRef, name),
       BQSchema.of(partitionField, BQField("num", BQField.Type.FLOAT64, BQField.Mode.REQUIRED)),
       BQPartitionType.DatePartitioned(partitionField.ident)
     )

--- a/core/src/test/scala/no/nrk/bigquery/BQTableIdTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQTableIdTest.scala
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets
 
 class BQTableIdTest extends munit.ScalaCheckSuite {
 
-  val dataset = BQDataset.unsafeOf(ProjectId.unsafeFromString("com-example"), "test")
+  val dataset = BQDataset.unsafeOf(ProjectId.unsafeFromString("com-example"), "test").toRef
 
   property("valid tableId") {
     Prop.forAll(Generators.validTableIdGen) { (input: String) =>
@@ -26,7 +26,7 @@ class BQTableIdTest extends munit.ScalaCheckSuite {
     Prop.forAll(Generators.validProjectIdGen, Generators.validDatasetIdGen, Generators.validTableIdGen) {
       (project: String, dataset: String, table: String) =>
         val obtained = BQTableId.fromString(s"${project}.${dataset}.${table}")
-        assertEquals(obtained, Right(BQTableId(BQDataset(ProjectId(project), dataset, None), table)))
+        assertEquals(obtained, Right(BQTableId(BQDataset.Ref(ProjectId(project), dataset), table)))
     }
   }
 
@@ -37,7 +37,7 @@ class BQTableIdTest extends munit.ScalaCheckSuite {
 
         val obtained =
           BQTableId.fromString(s"projects/${encode(project)}/datasets/${encode(dataset)}/tables/${encode(table)}")
-        assertEquals(obtained, Right(BQTableId(BQDataset(ProjectId(project), dataset, None), table)))
+        assertEquals(obtained, Right(BQTableId(BQDataset.Ref(ProjectId(project), dataset), table)))
     }
   }
 

--- a/core/src/test/scala/no/nrk/bigquery/TVFTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/TVFTest.scala
@@ -14,7 +14,7 @@ class TVFTest extends FunSuite {
 
   test("calling TVF with args") {
     val tvf = TVF(
-      TVF.TVFId(BQDataset.unsafeOf(ProjectId.unsafeFromString("my-test-project"), "my_cool_ds"), ident"tada"),
+      TVF.TVFId(BQDataset.unsafeOf(ProjectId.unsafeFromString("my-test-project"), "my_cool_ds").toRef, ident"tada"),
       BQPartitionType.NotPartitioned,
       BQRoutine.Params(BQRoutine.Param(ident"name", Some(BQType.STRING))),
       bqfr"select name",

--- a/core/src/test/scala/no/nrk/bigquery/UDFTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/UDFTest.scala
@@ -108,7 +108,7 @@ class UDFTest extends FunSuite {
     val udf = UDF
       .persistent(
         ident"fnName",
-        BQDataset(ProjectId("p1"), "ds1", None),
+        BQDataset.Ref(ProjectId("p1"), "ds1"),
         Params(Param("n", BQType.FLOAT64)),
         UDF.Body.Js("return n + 1", List("bucket/foo.js")),
         Some(BQType.FLOAT64)
@@ -120,7 +120,7 @@ class UDFTest extends FunSuite {
   test("render udf ref call") {
     val udf = UDF.reference(
       ident"fnName",
-      BQDataset(ProjectId("p1"), "ds1", None),
+      BQDataset.Ref(ProjectId("p1"), "ds1"),
       Params(Param("n", BQType.FLOAT64)),
       Some(BQType.FLOAT64)
     )

--- a/core/src/test/scala/no/nrk/bigquery/internal/RoutineUpdateOperationTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/internal/RoutineUpdateOperationTest.scala
@@ -19,7 +19,7 @@ class RoutineUpdateOperationTest extends FunSuite {
   private val udf: UDF.Persistent[_0] =
     UDF.persistent(
       ident"foo",
-      BQDataset(ProjectId("p1"), "ds1", None),
+      BQDataset.Ref(ProjectId("p1"), "ds1"),
       Params.empty,
       UDF.Body.Sql(bqfr"(1)"),
       Some(BQType.INT64))
@@ -66,7 +66,7 @@ class RoutineUpdateOperationTest extends FunSuite {
     val udf: UDF.Persistent[_1] =
       UDF.persistent(
         ident"foo",
-        BQDataset(ProjectId("p1"), "ds1", None),
+        BQDataset.Ref(ProjectId("p1"), "ds1"),
         Params(
           Param(
             "segments",

--- a/core/src/test/scala/no/nrk/bigquery/internal/TableUpdateOperationTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/internal/TableUpdateOperationTest.scala
@@ -19,12 +19,11 @@ class TableUpdateOperationTest extends FunSuite {
   private val a = BQField("a", BQField.Type.INT64, BQField.Mode.REQUIRED)
   private val b = BQField("b", BQField.Type.INT64, BQField.Mode.REQUIRED)
   private val c = BQField("c", BQField.Type.INT64, BQField.Mode.REQUIRED)
-  private val viewId = BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("project"), "dataset"), "view")
-  private val tableId = BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("project"), "dataset"), "table")
-  private val tableIdWithLocation =
-    BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("project"), "dataset", Some(LocationId.EuropeNorth1)), "table")
+  private val dataset: BQDataset.Ref = BQDataset.unsafeOf(ProjectId("project"), "dataset").toRef
+  private val viewId = BQTableId.unsafeOf(dataset, "view")
+  private val tableId = BQTableId.unsafeOf(dataset, "table")
   private val materializedViewId =
-    BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("project"), "dataset"), "mat_view")
+    BQTableId.unsafeOf(dataset, "mat_view")
 
   test("views with schema should trigger update after create") {
     val schema = BQSchema.of(a)
@@ -182,7 +181,7 @@ class TableUpdateOperationTest extends FunSuite {
 
   test("should be a noop when no fields has changed") {
     val givenTable = BQTableDef.Table(
-      tableIdWithLocation,
+      tableId,
       BQSchema.of(a, b),
       BQPartitionType.NotPartitioned,
       description = None,
@@ -192,7 +191,7 @@ class TableUpdateOperationTest extends FunSuite {
     val actualTable = Some(
       TableInfo
         .newBuilder(
-          tableIdWithLocation.underlying,
+          tableId.underlying,
           StandardTableDefinition.newBuilder
             .setSchema(SchemaHelper.toSchema(BQSchema.of(a, b)))
             .setLocation(LocationId.EuropeNorth1.value)

--- a/testing/src/test/scala/no/nrk/bigquery/TvfSmokeTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/TvfSmokeTest.scala
@@ -15,7 +15,7 @@ class TvfSmokeTest extends BQSmokeTest(BigQueryTestClient.testClient) {
   private val schema: BQSchema = BQSchema.of(
     BQField("id", BQField.Type.STRING, BQField.Mode.NULLABLE)
   )
-  private val myDataset: BQDataset = BQDataset(ProjectId.unsafeFromString("some-project"), "my-dataset", None)
+  private val myDataset: BQDataset.Ref = BQDataset(ProjectId.unsafeFromString("some-project"), "my-dataset", None).toRef
   private val sourceTable = BQTableDef.Table(
     BQTableId.unsafeOf(myDataset, "source-table"),
     schema,

--- a/zetasql/src/test/scala/no/nrk/bigquery/ZetaTest.scala
+++ b/zetasql/src/test/scala/no/nrk/bigquery/ZetaTest.scala
@@ -17,7 +17,7 @@ class ZetaTest extends munit.CatsEffectSuite {
   private lazy val zetaSql = new ZetaSql[IO]
 
   private val table = BQTableDef.Table(
-    BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("com-example"), "example"), "test"),
+    BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("com-example"), "example").toRef, "test"),
     BQSchema.of(
       BQField("partitionDate", BQField.Type.DATE, BQField.Mode.REQUIRED),
       BQField("a", BQField.Type.STRING, BQField.Mode.REQUIRED),
@@ -29,7 +29,7 @@ class ZetaTest extends munit.CatsEffectSuite {
   )
 
   private val table2 = BQTableDef.Table(
-    BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("com-example"), "example"), "test2"),
+    BQTableId.unsafeOf(BQDataset.unsafeOf(ProjectId("com-example"), "example").toRef, "test2"),
     BQSchema.of(
       BQField("partitionDate", BQField.Type.DATE, BQField.Mode.REQUIRED),
       BQField("name", BQField.Type.STRING, BQField.Mode.REQUIRED)
@@ -37,7 +37,7 @@ class ZetaTest extends munit.CatsEffectSuite {
     BQPartitionType.DatePartitioned(Ident("partitionDate"))
   )
   private val tvf = TVF(
-    TVF.TVFId(BQDataset.unsafeOf(ProjectId("com-example"), "example"), ident"tvftest"),
+    TVF.TVFId(BQDataset.unsafeOf(ProjectId("com-example"), "example").toRef, ident"tvftest"),
     BQPartitionType.NotPartitioned,
     BQRoutine.Params(BQRoutine.Param("d", BQType.DATE)),
     bqfr"select a from ${table.unpartitioned} where partitionDate = d",


### PR DESCRIPTION
When referencing a dataset we dont care about its location, this is mostly useful when creating / updating / getting a dataset.

Add implicit conversion to allow existing code to work.

We will now lose the ability to compare tables to make sure they are in the same location, by looking at the BQDataset. However, BQTableId.fromString does not care about location, and is probably the most used operation, we no longer lie in the definition in the table.

To make sure all tables are in the same location, you should check this by getting the datasets in all the projects referenced in the query.

This will assume that all tables are in a single location in for instance a join.