### PR TITLE
Metics track complete

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.tools.mima.core._
 
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.15" // your current series x.y
+ThisBuild / tlBaseVersion := "0.16" // your current series x.y
 
 ThisBuild / organization := "no.nrk.bigquery"
 ThisBuild / organizationName := "NRK"

--- a/core/src/main/scala/no/nrk/bigquery/metrics/BQMetrics.scala
+++ b/core/src/main/scala/no/nrk/bigquery/metrics/BQMetrics.scala
@@ -56,7 +56,7 @@ object BQMetrics {
       )
       jobResult <- Resource.eval(job)
       _ <- Resource.eval(
-        ops.recordTotalBytesBilled(
+        ops.recordComplete(
           jobResult.map(_.getStatistics[JobStatistics]),
           jobId
         )

--- a/core/src/main/scala/no/nrk/bigquery/metrics/MetricsOps.scala
+++ b/core/src/main/scala/no/nrk/bigquery/metrics/MetricsOps.scala
@@ -19,7 +19,7 @@ trait MetricsOps[F[_]] {
       terminationType: TerminationType,
       jobId: BQJobId
   ): F[Unit]
-  def recordTotalBytesBilled(
+  def recordComplete(
       jobStats: Option[JobStatistics],
       jobId: BQJobId
   ): F[Unit]
@@ -44,7 +44,7 @@ object MetricsOps {
         jobId: BQJobId
     ): F[Unit] = F.unit
 
-    override def recordTotalBytesBilled(
+    override def recordComplete(
         jobStats: Option[JobStatistics],
         jobId: BQJobId
     ): F[Unit] = F.unit


### PR DESCRIPTION
recordTotalBytesBilled is misnamed, and should be called recordComplete

register both totalSlotMs and totalBytesBilled metrics.