### PR TITLE
Implementation of bigquery-http4s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p transfer-client/.jvm/target google-client/.jvm/target codegen/.jvm/target prometheus/.jvm/target testing/.jvm/target core/.jvm/target zetasql/.jvm/target project/target
+        run: mkdir -p transfer-client/.jvm/target google-client/.jvm/target codegen/.jvm/target prometheus/.jvm/target testing/.jvm/target http4s-client/.jvm/target core/.jvm/target zetasql/.jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar transfer-client/.jvm/target google-client/.jvm/target codegen/.jvm/target prometheus/.jvm/target testing/.jvm/target core/.jvm/target zetasql/.jvm/target project/target
+        run: tar cf targets.tar transfer-client/.jvm/target google-client/.jvm/target codegen/.jvm/target prometheus/.jvm/target testing/.jvm/target http4s-client/.jvm/target core/.jvm/target zetasql/.jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,17 @@ val commonSettings = Seq(
 lazy val root = tlCrossRootProject
   .settings(name := "bigquery-scala")
   .settings(commonSettings)
-  .aggregate(core, `google-client`, testing, prometheus, zetasql, codegen, codegenTests, `transfer-client`, docs)
+  .aggregate(
+    core,
+    `google-client`,
+    `http4s-client`,
+    testing,
+    prometheus,
+    zetasql,
+    codegen,
+    codegenTests,
+    `transfer-client`,
+    docs)
 
 lazy val core = crossProject(JVMPlatform)
   .withoutSuffixFor(JVMPlatform)
@@ -136,6 +146,29 @@ lazy val `google-client` = crossProject(JVMPlatform)
     mimaBinaryIssueFilters := Nil
   )
 
+lazy val `http4s-client` = crossProject(JVMPlatform)
+  .withoutSuffixFor(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("http4s-client"))
+  .dependsOn(core)
+  .settings(commonSettings)
+  .settings(
+    resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
+    name := "bigquery-http4s-client",
+    libraryDependencies ++= Seq(
+      "org.scalameta" %% "munit-scalacheck" % "0.7.29" % Test,
+      "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % Test,
+      "io.chrisdavenport" %% "http4s-grpc-google-cloud-bigquerystorage-v1" % "3.0.0+0.0.6",
+      "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3-a13d31c-v2-20240214-SNAPSHOT",
+      "org.http4s" %% "http4s-netty-client" % "0.5.12",
+      "com.permutive" %% "gcp-auth" % "0.1.0"
+    ),
+    Compile / doc / scalacOptions ++= Seq(
+      "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
+    ),
+    mimaBinaryIssueFilters := Nil
+  )
+
 lazy val prometheus = crossProject(JVMPlatform)
   .withoutSuffixFor(JVMPlatform)
   .crossType(CrossType.Pure)
@@ -185,7 +218,7 @@ lazy val testing = crossProject(JVMPlatform)
   .withoutSuffixFor(JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("testing"))
-  .dependsOn(core, `google-client` % Test)
+  .dependsOn(core, `google-client` % Test, `http4s-client` % Test)
   .settings(commonSettings)
   .settings(
     name := "bigquery-testing",

--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,7 @@ lazy val testing = crossProject(JVMPlatform)
     libraryDependencies ++= Seq(
       "org.scalameta" %% "munit" % "0.7.29",
       "org.typelevel" %% "munit-cats-effect-3" % "1.0.7",
-      "ch.qos.logback" % "logback-classic" % "1.5.3" % Test,
+      "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,
       "org.http4s" %% "http4s-netty-client" % "0.5.15"
     ),
     mimaBinaryIssueFilters := Nil

--- a/build.sbt
+++ b/build.sbt
@@ -155,14 +155,24 @@ lazy val `http4s-client` = crossProject(JVMPlatform)
   .settings(
     resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
     name := "bigquery-http4s-client",
-    libraryDependencies ++= Seq(
-      "org.scalameta" %% "munit-scalacheck" % "0.7.29" % Test,
-      "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % Test,
-      "io.chrisdavenport" %% "http4s-grpc-google-cloud-bigquerystorage-v1" % "3.0.0+0.0.6",
-      "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3.0-v2-20240214",
-      "org.http4s" %% "http4s-netty-client" % "0.5.12",
-      "com.permutive" %% "gcp-auth" % "0.1.0"
-    ),
+    libraryDependencies ++= {
+      val binaryVersion = scalaBinaryVersion.value
+      Seq(
+        "org.scalameta" %% "munit-scalacheck" % "0.7.29" % Test,
+        "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % Test,
+        ("io.chrisdavenport" %% "http4s-grpc-google-cloud-bigquerystorage-v1" % "3.0.0+0.0.6")
+          .exclude("io.chrisdavenport", s"http4s-grpc_${binaryVersion}"),
+        ("io.chrisdavenport" %% "http4s-grpc" % "0.0.4")
+          .exclude("org.http4s", s"http4s-ember-server_${binaryVersion}")
+          .exclude("org.http4s", s"http4s-ember-client_${binaryVersion}")
+          .exclude("org.http4s", s"http4s-dsl_${binaryVersion}"),
+        // needed because of hard-link in http4s-grpc
+        // https://github.com/davenverse/http4s-grpc/pull/89
+        "org.http4s" %% "http4s-ember-core" % "0.23.25",
+        "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3.0-v2-20240214",
+        "com.permutive" %% "gcp-auth" % "0.1.0"
+      )
+    },
     Compile / doc / scalacOptions ++= Seq(
       "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
     ),
@@ -225,7 +235,8 @@ lazy val testing = crossProject(JVMPlatform)
     libraryDependencies ++= Seq(
       "org.scalameta" %% "munit" % "0.7.29",
       "org.typelevel" %% "munit-cats-effect-3" % "1.0.7",
-      "ch.qos.logback" % "logback-classic" % "1.5.3" % Test
+      "ch.qos.logback" % "logback-classic" % "1.5.3" % Test,
+      "org.http4s" %% "http4s-netty-client" % "0.5.15"
     ),
     mimaBinaryIssueFilters := Nil
   )

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ lazy val `http4s-client` = crossProject(JVMPlatform)
       "org.scalameta" %% "munit-scalacheck" % "0.7.29" % Test,
       "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % Test,
       "io.chrisdavenport" %% "http4s-grpc-google-cloud-bigquerystorage-v1" % "3.0.0+0.0.6",
-      "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3-a13d31c-v2-20240214-SNAPSHOT",
+      "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3.0-v2-20240214",
       "org.http4s" %% "http4s-netty-client" % "0.5.12",
       "com.permutive" %% "gcp-auth" % "0.1.0"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val `http4s-client` = crossProject(JVMPlatform)
         // needed because of hard-link in http4s-grpc
         // https://github.com/davenverse/http4s-grpc/pull/89
         "org.http4s" %% "http4s-ember-core" % "0.23.25",
-        "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3.0-10-1cda9bd-v2-20240229-SNAPSHOT",
+        "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.4.0-v2-20240229",
         "com.permutive" %% "gcp-auth" % "0.1.0"
       )
     },

--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val `http4s-client` = crossProject(JVMPlatform)
         // needed because of hard-link in http4s-grpc
         // https://github.com/davenverse/http4s-grpc/pull/89
         "org.http4s" %% "http4s-ember-core" % "0.23.25",
-        "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3.0-v2-20240214",
+        "net.hamnaberg.googleapis" %% "googleapis-http4s-bigquery" % "0.3.0-10-1cda9bd-v2-20240229-SNAPSHOT",
         "com.permutive" %% "gcp-auth" % "0.1.0"
       )
     },

--- a/core/src/main/scala/no/nrk/bigquery/QueryClient.scala
+++ b/core/src/main/scala/no/nrk/bigquery/QueryClient.scala
@@ -188,7 +188,8 @@ object QueryClient {
   case class PollConfig(
       baseDelay: FiniteDuration = 3.second,
       maxDuration: FiniteDuration = 20.minutes,
-      maxErrorsTolerated: Int = 10
+      maxErrorsTolerated: Int = 10,
+      maxRetryNotFound: Int = 5
   )
 
   type Aux[F[_], J] = QueryClient[F] {

--- a/google-client/src/main/scala/no/nrk/bigquery/client/google/internal/GoogleBQPollImpl.scala
+++ b/google-client/src/main/scala/no/nrk/bigquery/client/google/internal/GoogleBQPollImpl.scala
@@ -16,9 +16,6 @@ private[client] object GoogleBQPollImpl {
     override def reference(job: Job): BQJobId =
       GoogleTypeHelper.jobIdFromJob(job)
 
-    override def id(job: Job): Option[String] =
-      Option(job.getJobId).flatMap(j => Option(j.getJob))
-
     override def toPoll(job: Job): BQPoll = {
       val maybeStatus: Option[JobStatus] =
         Option(job.getStatus)

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/EnsureUpdated.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/EnsureUpdated.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.client.http4s
+
+import cats.MonadThrow
+import googleapis.bigquery.{Routine, Table}
+import no.nrk.bigquery.internal.EnsureUpdatedBase
+import org.typelevel.log4cats.LoggerFactory
+
+class EnsureUpdated[F[_]](client: Http4sBigQueryClient[F])(implicit F: MonadThrow[F], lf: LoggerFactory[F])
+    extends EnsureUpdatedBase[F, Routine, Table](client)

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sAdminClient.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sAdminClient.scala
@@ -57,7 +57,7 @@ class Http4sAdminClient[F[_]] private (client: Client[F])(implicit F: Async[F])
   override def datasetsInProject(project: ProjectId): F[Vector[BQDataset]] =
     fs2.Stream
       .unfoldLoopEval(
-        DatasetsClient.ListGetParams(maxResults = Some(100))
+        DatasetsClient.ListParams(maxResults = Some(100))
       )(params =>
         datasetClient
           .list(project.value, query = params)
@@ -109,7 +109,7 @@ class Http4sAdminClient[F[_]] private (client: Client[F])(implicit F: Async[F])
   override def tablesInDataset(dataset: BQDataset.Ref): F[Vector[BQTableRef[Any]]] =
     fs2.Stream
       .unfoldLoopEval(
-        TablesClient.ListGetParams(maxResults = Some(100))
+        TablesClient.ListParams(maxResults = Some(100))
       )(params =>
         tableClient
           .list(dataset.project.value, dataset.id, query = params)
@@ -154,7 +154,7 @@ class Http4sAdminClient[F[_]] private (client: Client[F])(implicit F: Async[F])
   override def routinesInDataset(dataset: BQDataset.Ref): F[Vector[BQPersistentRoutine.Unknown]] =
     fs2.Stream
       .unfoldLoopEval(
-        RoutinesClient.ListGetParams(maxResults = Some(100))
+        RoutinesClient.ListParams(maxResults = Some(100))
       )(params =>
         routineClient
           .list(dataset.project.value, dataset.id, query = params)

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sAdminClient.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sAdminClient.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.client.http4s
+
+import cats.effect.Async
+import cats.syntax.all.*
+import googleapis.bigquery.*
+import no.nrk.bigquery.*
+import no.nrk.bigquery.client.http4s.internal.{RoutineHelper, TableHelper}
+import org.http4s.client.Client
+
+class Http4sAdminClient[F[_]] private (client: Client[F])(implicit F: Async[F])
+    extends BQAdminClientWithUnderlying[F, Routine, Table] {
+  private val tableClient = new TablesClient[F](client)
+  private val routineClient = new RoutinesClient[F](client)
+  private val datasetClient = new DatasetsClient[F](client)
+
+  private def toMaybe[A](either: Either[Throwable, A]): F[Option[A]] =
+    either match {
+      case Left(GoogleError(Some(404), _, _, _)) => F.pure(none[A])
+      case Left(err) => F.raiseError(err)
+      case Right(value) => F.pure(value.some)
+    }
+
+  override def getTableWithUnderlying(tableId: BQTableId): F[Option[ExistingTable[Table]]] =
+    tableClient
+      .get(tableId.dataset.project.value, tableId.dataset.id, tableId.tableName)
+      .attempt
+      .flatMap(toMaybe)
+      .map(_.flatMap(t => TableHelper.fromGoogle(t).toOption.map(ExistingTable(_, t))))
+
+  override def updateTableWithExisting(existing: ExistingTable[Table], table: BQTableDef[Any]): F[BQTableDef[Any]] = {
+    val updated = TableHelper.toGoogle(table, Some(existing.table))
+
+    tableClient
+      .update(table.tableId.dataset.project.value, table.tableId.dataset.id, table.tableId.tableName)(updated)
+      .as(table)
+  }
+
+  override def createDataset(dataset: BQDataset): F[BQDataset] =
+    datasetClient
+      .insert(dataset.project.value)(
+        Dataset(
+          datasetReference =
+            Some(DatasetReference(projectId = Some(dataset.project.value), datasetId = Some(dataset.id))),
+          location = dataset.location.map(_.value)
+        ))
+      .as(dataset)
+
+  override def deleteDataset(dataset: BQDataset.Ref): F[Boolean] =
+    datasetClient.delete(dataset.project.value, dataset.id).map(_.isSuccess)
+
+  override def datasetsInProject(project: ProjectId): F[Vector[BQDataset]] =
+    fs2.Stream
+      .unfoldLoopEval(
+        DatasetsClient.ListGetParams(maxResults = Some(100))
+      )(params =>
+        datasetClient
+          .list(project.value, query = params)
+          .map(list =>
+            list.datasets.getOrElse(Nil) -> list.nextPageToken.map(tok => params.copy(pageToken = Some(tok)))))
+      .flatMap(fs2.Stream.emits)
+      .mapFilter(ds =>
+        for {
+          project <- ds.datasetReference.flatMap(_.projectId).map(ProjectId.unsafeFromString)
+          id <- ds.datasetReference.flatMap(_.datasetId)
+          location = ds.location.map(LocationId.apply)
+        } yield BQDataset(project, id, location))
+      .compile
+      .toVector
+
+  override def getDataset(dataset: BQDataset.Ref): F[Option[BQDataset]] =
+    datasetClient
+      .get(dataset.project.value, dataset.id)
+      .attempt
+      .flatMap(toMaybe)
+      .map(_.flatMap(toDataset))
+
+  private def toDataset(ds: Dataset) =
+    for {
+      project <- ds.datasetReference.flatMap(_.projectId).map(ProjectId.unsafeFromString)
+      id <- ds.datasetReference.flatMap(_.datasetId)
+      location = ds.location.map(LocationId.apply)
+    } yield BQDataset(project, id, location)
+
+  override def getTable(tableId: BQTableId): F[Option[BQTableDef[Any]]] =
+    getTableWithUnderlying(tableId).map(_.map(_.our))
+
+  override def createTable(table: BQTableDef[Any]): F[BQTableDef[Any]] =
+    tableClient
+      .insert(table.tableId.dataset.project.value, table.tableId.dataset.id)(TableHelper.toGoogle(table, None))
+      .as(table)
+
+  override def updateTable(table: BQTableDef[Any]): F[BQTableDef[Any]] =
+    tableClient
+      .update(table.tableId.dataset.project.value, table.tableId.dataset.id, table.tableId.tableName)(
+        TableHelper.toGoogle(table, None))
+      .as(table)
+
+  override def deleteTable(tableId: BQTableId): F[Boolean] =
+    tableClient
+      .delete(tableId.dataset.project.value, tableId.dataset.id, tableId.tableName)
+      .map(_.isSuccess)
+
+  override def tablesInDataset(dataset: BQDataset.Ref): F[Vector[BQTableRef[Any]]] =
+    fs2.Stream
+      .unfoldLoopEval(
+        TablesClient.ListGetParams(maxResults = Some(100))
+      )(params =>
+        tableClient
+          .list(dataset.project.value, dataset.id, query = params)
+          .map(list => list.tables.getOrElse(Nil) -> list.nextPageToken.map(tok => params.copy(pageToken = Some(tok)))))
+      .flatMap(fs2.Stream.emits)
+      .mapFilter(table => TableHelper.refFromGoogle(table).toOption)
+      .compile
+      .toVector
+
+  override def getRoutineWithUnderlying(id: BQPersistentRoutine.Id): F[Option[ExistingRoutine[Routine]]] =
+    routineClient
+      .get(id.dataset.project.value, id.dataset.id, id.name.value)
+      .attempt
+      .flatMap(toMaybe)
+      .map(_.flatMap(r => RoutineHelper.fromGoogle(r).toOption.map(ExistingRoutine(_, r))))
+
+  override def updateRoutineWithExisting(
+      existing: ExistingRoutine[Routine],
+      routine: BQPersistentRoutine.Unknown): F[BQPersistentRoutine.Unknown] =
+    routineClient
+      .update(existing.our.name.dataset.project.value, existing.our.name.dataset.id, existing.our.name.name.value)(
+        RoutineHelper.toGoogle(routine, Some(existing.routine)))
+      .as(routine)
+
+  override def getRoutine(id: BQPersistentRoutine.Id): F[Option[BQPersistentRoutine.Unknown]] =
+    getRoutineWithUnderlying(id).map(_.map(_.our))
+
+  override def createRoutine(routine: BQPersistentRoutine.Unknown): F[BQPersistentRoutine.Unknown] =
+    routineClient
+      .insert(routine.name.dataset.project.value, routine.name.dataset.id)(RoutineHelper.toGoogle(routine, None))
+      .as(routine)
+
+  override def updateRoutine(routine: BQPersistentRoutine.Unknown): F[BQPersistentRoutine.Unknown] =
+    routineClient
+      .update(routine.name.dataset.project.value, routine.name.dataset.id, routine.name.name.value)(
+        RoutineHelper.toGoogle(routine, None))
+      .as(routine)
+
+  override def deleteRoutine(id: BQPersistentRoutine.Id): F[Boolean] =
+    routineClient.delete(id.dataset.project.value, id.dataset.id, id.name.value).map(_.isSuccess)
+
+  override def routinesInDataset(dataset: BQDataset.Ref): F[Vector[BQPersistentRoutine.Unknown]] =
+    fs2.Stream
+      .unfoldLoopEval(
+        RoutinesClient.ListGetParams(maxResults = Some(100))
+      )(params =>
+        routineClient
+          .list(dataset.project.value, dataset.id, query = params)
+          .map(list =>
+            list.routines.getOrElse(Nil) -> list.nextPageToken.map(tok => params.copy(pageToken = Some(tok)))))
+      .flatMap(fs2.Stream.emits)
+      .mapFilter(routine => RoutineHelper.fromGoogle(routine).toOption)
+      .compile
+      .toVector
+}
+
+object Http4sAdminClient {
+  def fromClient[F[_]: Async](client: Client[F]): Http4sAdminClient[F] =
+    new Http4sAdminClient[F](client)
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sBigQueryClient.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sBigQueryClient.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.client.http4s
+
+import cats.effect.{Async, Resource}
+import cats.syntax.all.*
+import com.permutive.gcp.auth.TokenProvider
+import fs2.io.file.{Files, Path}
+import googleapis.bigquery.{Routine, Table}
+import io.circe.Encoder
+import no.nrk.bigquery.*
+import no.nrk.bigquery.BQPersistentRoutine.Unknown
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+import org.http4s.client.Client
+import org.http4s.client.middleware.{Retry, RetryPolicy as HttpRetryPolicy}
+import org.typelevel.log4cats.LoggerFactory
+import retry.RetryPolicies.constantDelay
+
+import scala.concurrent.duration.*
+
+class Http4sBigQueryClient[F[_]: Async: LoggerFactory](
+    client: Client[F],
+    defaults: BQClientDefaults,
+    pollConfig: QueryClient.PollConfig)
+    extends QueryClient[F]
+    with BQAdminClientWithUnderlying[F, Routine, Table] {
+  val queryClient = Http4sQueryClient.fromClient(client, defaults, pollConfig)
+  val adminClient = Http4sAdminClient.fromClient(client)
+
+  override type Job = queryClient.Job
+
+  override protected[bigquery] def synchronousQueryExecute(
+      jobId: BQJobId,
+      query: BQSqlFrag,
+      legacySql: Boolean,
+      logStream: Boolean): Resource[F, (Schema, fs2.Stream[F, GenericRecord])] =
+    queryClient.synchronousQueryExecute(jobId, query, legacySql, logStream)
+
+  override def loadToHashedPartition[A](
+      jobId: BQJobId,
+      table: BQTableDef.Table[Long],
+      stream: fs2.Stream[F, A],
+      logStream: Boolean,
+      chunkSize: Int)(implicit hashedEncoder: HashedPartitionEncoder[A]): F[Option[BQJobStatistics.Load]] =
+    queryClient.loadToHashedPartition(jobId, table, stream, logStream, chunkSize)
+
+  /** @return
+    *   None, if `chunkedStream` is empty
+    */
+  override def loadJson[A: Encoder, P: TableOps](
+      jobId: BQJobId,
+      table: BQTableDef.Table[P],
+      partition: P,
+      stream: fs2.Stream[F, A],
+      writeDisposition: WriteDisposition,
+      logStream: Boolean,
+      chunkSize: Int): F[Option[BQJobStatistics.Load]] =
+    queryClient.loadJson(jobId, table, partition, stream, writeDisposition, logStream, chunkSize)
+
+  override def submitQuery[P](
+      id: BQJobId,
+      query: BQSqlFrag,
+      destination: Option[BQPartitionId[P]],
+      writeDisposition: Option[WriteDisposition]): F[JobWithStats[Job]] =
+    queryClient.submitQuery(id, query, destination, writeDisposition)
+
+  override def dryRun(id: BQJobId, query: BQSqlFrag): F[BQJobStatistics.Query] =
+    queryClient.dryRun(id, query)
+
+  override def getTableWithUnderlying(id: BQTableId): F[Option[ExistingTable[Table]]] =
+    adminClient.getTableWithUnderlying(id)
+
+  override def updateTableWithExisting(existing: ExistingTable[Table], table: BQTableDef[Any]): F[BQTableDef[Any]] =
+    adminClient.updateTableWithExisting(existing, table)
+
+  override def getRoutineWithUnderlying(id: BQPersistentRoutine.Id): F[Option[ExistingRoutine[Routine]]] =
+    adminClient.getRoutineWithUnderlying(id)
+
+  override def updateRoutineWithExisting(existing: ExistingRoutine[Routine], routine: Unknown): F[Unknown] =
+    adminClient.updateRoutineWithExisting(existing, routine)
+
+  override def createDataset(dataset: BQDataset): F[BQDataset] =
+    adminClient.createDataset(dataset)
+
+  override def deleteDataset(dataset: BQDataset.Ref): F[Boolean] =
+    adminClient.deleteDataset(dataset)
+
+  override def datasetsInProject(project: ProjectId): F[Vector[BQDataset]] =
+    adminClient.datasetsInProject(project)
+
+  override def getDataset(dataset: BQDataset.Ref): F[Option[BQDataset]] =
+    adminClient.getDataset(dataset)
+
+  override def getTable(tableId: BQTableId): F[Option[BQTableDef[Any]]] =
+    adminClient.getTable(tableId)
+
+  override def createTable(table: BQTableDef[Any]): F[BQTableDef[Any]] =
+    adminClient.createTable(table)
+
+  override def updateTable(table: BQTableDef[Any]): F[BQTableDef[Any]] =
+    adminClient.updateTable(table)
+
+  override def deleteTable(tableId: BQTableId): F[Boolean] =
+    adminClient.deleteTable(tableId)
+
+  override def tablesInDataset(dataset: BQDataset.Ref): F[Vector[BQTableRef[Any]]] =
+    adminClient.tablesInDataset(dataset)
+
+  override def getRoutine(id: BQPersistentRoutine.Id): F[Option[Unknown]] =
+    adminClient.getRoutine(id)
+
+  override def createRoutine(routine: Unknown): F[Unknown] =
+    adminClient.createRoutine(routine)
+
+  override def updateRoutine(routine: Unknown): F[Unknown] =
+    adminClient.updateRoutine(routine)
+
+  override def deleteRoutine(id: BQPersistentRoutine.Id): F[Boolean] =
+    adminClient.deleteRoutine(id)
+
+  override def routinesInDataset(dataset: BQDataset.Ref): F[Vector[Unknown]] =
+    adminClient.routinesInDataset(dataset)
+
+  override def createTempTable[Param](
+      table: BQTableDef.Table[Param],
+      tmpDataset: BQDataset.Ref,
+      expirationDuration: Option[FiniteDuration]): F[BQTableDef.Table[Param]] =
+    queryClient.createTempTable(table, tmpDataset, expirationDuration)
+
+  override def createTempTableResource[Param](
+      table: BQTableDef.Table[Param],
+      tmpDataset: BQDataset.Ref): Resource[F, BQTableDef.Table[Param]] =
+    queryClient.createTempTableResource(table, tmpDataset)
+}
+
+object Http4sBigQueryClient {
+  val DEFAULT_SCOPES = "https://www.googleapis.com/auth/bigquery" :: Nil
+
+  def serviceAccount[F[_]: Async: Files](path: Path, client: Client[F]): F[TokenProvider[F]] =
+    TokenProvider.serviceAccount(path, DEFAULT_SCOPES, client)
+
+  def serviceAccountFromString[F[_]: Async: Files](input: String, client: Client[F]): F[TokenProvider[F]] =
+    Files[F].tempFile.use { path =>
+      fs2.Stream.emit(input).through(Files[F].writeUtf8(path)).compile.drain >>
+        serviceAccount[F](path, client)
+    }
+
+  def withMiddlewares[F[_]: Async](
+      client: Client[F],
+      retry: HttpRetryPolicy[F] = HttpRetryPolicy[F](backoff = x => if (x < 3) Some((x * 3).seconds) else None),
+      authentication: TokenProvider[F]): Client[F] =
+    Retry(retry)(authentication.clientMiddleware(client))
+
+  def defaultCached[F[_]: Async] = TokenProvider
+    .cached[F]
+    .safetyPeriod(4.seconds)
+    .onRefreshFailure { case (_, _) => Async[F].unit }
+    .onExhaustedRetries(_ => Async[F].unit)
+    .onNewToken { case (_, _) => Async[F].unit }
+    .retryPolicy(constantDelay[F](200.millis))
+
+  def resource[F[_]: Async: LoggerFactory](
+      client: Client[F],
+      defaults: BQClientDefaults,
+      authentication: TokenProvider[F],
+      pollConfig: QueryClient.PollConfig = QueryClient.PollConfig(),
+      retry: HttpRetryPolicy[F] = HttpRetryPolicy[F](backoff = x => if (x < 3) Some((x * 3).seconds) else None),
+      configureAuth: Option[(TokenProvider.CachedBuilder[F]) => TokenProvider.CachedBuilder[F]] = None
+  ): Resource[F, Http4sBigQueryClient[F]] =
+    for {
+      auth <- configureAuth
+        .getOrElse(identity[TokenProvider.CachedBuilder[F]])(defaultCached)
+        .build(authentication)
+      middle = withMiddlewares(client, retry, auth)
+    } yield new Http4sBigQueryClient(middle, defaults, pollConfig)
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sImplicits.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sImplicits.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.client.http4s
+
+import cats.effect.Concurrent
+import io.circe.{Decoder, Encoder}
+import org.http4s.{EntityDecoder, EntityEncoder}
+
+private[client] object Http4sImplicits {
+  private[client] implicit def entityEncoder[F[_], A: Encoder]: EntityEncoder[F, A] =
+    org.http4s.circe.jsonEncoderOf[F, A]
+
+  private[client] implicit def entityDecoder[F[_]: Concurrent, A: Decoder]: EntityDecoder[F, A] =
+    org.http4s.circe.jsonOf[F, A]
+
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.client.http4s
+
+import cats.data.OptionT
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.syntax.all.*
+import com.google.cloud.bigquery.storage.v1.storage.{
+  BigQueryRead,
+  CreateReadSessionRequest,
+  ReadRowsRequest,
+  ReadRowsResponse
+}
+import com.google.cloud.bigquery.storage.v1.stream.{DataFormat, ReadSession}
+import fs2.{Chunk, Pipe, Stream}
+import googleapis.bigquery.*
+import io.circe.*
+import io.circe.syntax.EncoderOps
+import no.nrk.bigquery.*
+import no.nrk.bigquery.client.http4s.internal.{JobHelper, SchemaHelper, TableHelper}
+import no.nrk.bigquery.util.StreamUtils
+import org.apache.avro.Schema
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
+import org.apache.avro.io.DecoderFactory
+import org.http4s.*
+import org.http4s.client.Client
+import org.http4s.syntax.literals.*
+import org.typelevel.log4cats.LoggerFactory
+
+import java.util.UUID
+import scala.concurrent.duration.*
+
+class Http4sQueryClient[F[_]] private (
+    client: Client[F],
+    defaults: BQClientDefaults,
+    pollConfig: QueryClient.PollConfig)(implicit F: Async[F], lf: LoggerFactory[F])
+    extends QueryClient[F] {
+  import no.nrk.bigquery.client.http4s.internal.Http4sBQPollImpl.*
+  private val logger = lf.getLogger
+  private val jobsClient = new JobsClient(client)
+  private val tableClient = new TablesClient[F](client)
+  private val poller = new BQPoll.Poller[F](pollConfig)
+  private val bqRead = BigQueryRead.fromClient[F](client, uri"https://bigquerystorage.googleapis.com")
+  import Http4sImplicits.*
+
+  type Job = googleapis.bigquery.Job
+
+  override protected[bigquery] def synchronousQueryExecute(
+      jobId: BQJobId,
+      query: BQSqlFrag,
+      legacySql: Boolean,
+      logStream: Boolean): Resource[F, (Schema, Stream[F, GenericRecord])] = {
+    def openServerStreams(job: Job, numStreams: Int): F[(ReadSession, List[Stream[F, ReadRowsResponse]])] =
+      for {
+        tempTable <- F.delay(
+          job.configuration
+            .flatMap(
+              _.query
+                .flatMap(_.destinationTable)
+                .flatMap(TableHelper.fromTableReference))
+            .getOrElse(throw new IllegalStateException(s"Unable to get destination table from ${job.jobReference}")))
+        request = CreateReadSessionRequest.defaultInstance
+          .withParent("projects/" + tempTable.dataset.project.value)
+          .withReadSession(
+            ReadSession.defaultInstance.withTable(tempTable.asPathString).withDataFormat(DataFormat.AVRO))
+          .withMaxStreamCount(numStreams)
+          .withPreferredMinStreamCount(1)
+
+        session <- bqRead.createReadSession(
+          request,
+          Headers(
+            "content-type" -> "application/grpc",
+            "user-agent" -> "http4s-bigquery",
+            "x-goog-request-params" -> s"read_session.table=${Uri.Path.Segment(tempTable.asPathString).encoded}"
+          )
+        )
+        serverStreams = session.streams.toList.map { streamN =>
+          bqRead.readRows(
+            ReadRowsRequest.defaultInstance.withReadStream(streamN.name),
+            Headers(
+              "content-type" -> "application/grpc",
+              "user-agent" -> "http4s-bigquery",
+              "x-goog-request-params" -> s"read_stream=${Uri.Path.Segment(streamN.name).encoded}")
+          )
+        }
+      } yield (session, serverStreams)
+
+    def rows(datumReader: GenericDatumReader[GenericRecord]): Pipe[F, ReadRowsResponse, GenericRecord] =
+      _.flatMap(res =>
+        Stream.chunk(
+          res.rows.avroRows
+            .map { rows =>
+              val b = Vector.newBuilder[GenericRecord]
+
+              val decoder =
+                DecoderFactory.get.binaryDecoder(rows.serializedBinaryRows.toByteArray, null)
+
+              while (!decoder.isEnd)
+                b += datumReader.read(null, decoder)
+              Chunk.from(b.result())
+            }
+            .getOrElse(Chunk.empty)))
+
+    val run = for {
+      job <- submitQueryImpl(jobId, query, legacySql, None, None)
+      tuple <- openServerStreams(job.job, 4)
+      (session, streams) = tuple
+      schema <- F.delay(
+        new Schema.Parser()
+          .parse(session.schema.avroSchema.map(_.schema).getOrElse(sys.error("No avro schema from session"))))
+      datumReader = new GenericDatumReader[GenericRecord](schema)
+      baseStream = streams.map(_.through(rows(datumReader))).reduceOption(_.merge(_)).getOrElse(Stream.empty)
+      rowStream =
+        if (logStream) {
+          baseStream.chunks
+            .through(StreamUtils.logChunks(logger, None, "downloading"))
+            .flatMap(Stream.chunk)
+
+        } else baseStream
+    } yield schema -> rowStream
+
+    Resource.eval(run)
+  }
+
+  override def loadToHashedPartition[A](
+      jobId: BQJobId,
+      table: BQTableDef.Table[Long],
+      stream: fs2.Stream[F, A],
+      logStream: Boolean,
+      chunkSize: Int)(implicit hashedEncoder: HashedPartitionEncoder[A]): F[Option[BQJobStatistics.Load]] = {
+    val partitionType = table.partitionType match {
+      case x: BQPartitionType.IntegerRangePartitioned => x
+    }
+
+    loadJson(
+      jobId,
+      table.tableId,
+      table.schema,
+      stream.map(x => hashedEncoder.toJson(x, partitionType)),
+      WriteDisposition.WRITE_APPEND,
+      logStream,
+      chunkSize
+    )
+  }
+
+  /** @return
+    *   None, if `chunkedStream` is empty
+    */
+  override def loadJson[A: Encoder, P: TableOps](
+      jobId: BQJobId,
+      table: BQTableDef.Table[P],
+      partition: P,
+      stream: fs2.Stream[F, A],
+      writeDisposition: WriteDisposition,
+      logStream: Boolean,
+      chunkSize: Int): F[Option[BQJobStatistics.Load]] =
+    loadJson(
+      jobId,
+      table.assertPartition(partition).asTableId,
+      table.schema,
+      stream,
+      writeDisposition,
+      logStream,
+      chunkSize)
+
+  override def submitQuery[P](
+      id: BQJobId,
+      query: BQSqlFrag,
+      destination: Option[BQPartitionId[P]],
+      writeDisposition: Option[WriteDisposition]): F[JobWithStats[Job]] =
+    submitQueryImpl(
+      id = id,
+      query = query,
+      legacySql = false,
+      destination = destination,
+      writeDisposition = writeDisposition)
+
+  private def submitQueryImpl[P](
+      id: BQJobId,
+      query: BQSqlFrag,
+      legacySql: Boolean,
+      destination: Option[BQPartitionId[P]],
+      writeDisposition: Option[WriteDisposition]): F[JobWithStats[Job]] = {
+    val project = id.projectId.getOrElse(defaults.projectId)
+
+    val submitted = submitJob(id) { ref =>
+      val jobSpec = Job(
+        jobReference = Some(ref),
+        configuration = Some(
+          JobConfiguration(
+            jobType = Some("QUERY"),
+            query = Some(JobConfigurationQuery(
+              query = Some(query.asStringWithUDFs),
+              useLegacySql = Some(legacySql),
+              writeDisposition = writeDisposition.map(_.name),
+              destinationTable = destination.map(p => TableHelper.toTableReference(p.asTableId))
+            )),
+            labels = Some(id.labels.value)
+          ))
+      )
+      jobsClient.insert(project.value)(jobSpec).map(_.some).recoverWith {
+        case err: GoogleError if err.code.contains(Status.Conflict.code) =>
+          OptionT.fromOption[F](ref.jobId).semiflatMap(id => jobsClient.get(project.value, id)).value
+      }
+    }
+    def toJobStats(job: Job) =
+      for {
+        id <- JobHelper.jobId(job)
+        stats <- job.statistics
+        qstats <- JobHelper.toQueryStats(id, stats)
+      } yield JobWithStats(job, qstats)
+
+    OptionT(submitted)
+      .subflatMap(toJobStats)
+      .getOrElseF(F.raiseError(new Exception(s"Unexpected: got no job after submitting ${id.name}")))
+  }
+
+  override def dryRun(id: BQJobId, query: BQSqlFrag): F[BQJobStatistics.Query] = {
+    val submitted = OptionT
+      .liftF(
+        freshJobReference(id)
+          .flatMap { ref =>
+            val project = id.projectId.getOrElse(defaults.projectId)
+            val jobSpec = Job(
+              jobReference = Some(ref),
+              configuration = Some(
+                JobConfiguration(
+                  query = Some(
+                    JobConfigurationQuery(
+                      query = Some(query.asStringWithUDFs),
+                      useLegacySql = Some(false)
+                    )),
+                  labels = Some(id.labels.value),
+                  dryRun = Some(true),
+                  jobType = Some("QUERY")
+                ))
+            )
+            jobsClient.insert(project.value)(jobSpec)
+          })
+
+    def toJobStats(job: Job) =
+      for {
+        id <- JobHelper.jobId(job)
+        stats <- job.statistics
+        qstats <- JobHelper.toQueryStats(id, stats)
+      } yield qstats
+
+    submitted
+      .subflatMap(toJobStats)
+      .getOrElseF(F.raiseError(new Exception(s"Unexpected: got no job after submitting ${id.name}")))
+  }
+
+  def submitJob(jobId: BQJobId)(runRef: JobReference => F[Option[Job]]): F[Option[Job]] = {
+    val project = jobId.projectId.getOrElse(defaults.projectId)
+
+    val run: (JobReference) => F[Option[Job]] = { ref =>
+      runRef(ref).flatMap {
+        case Some(job) =>
+          poller
+            .poll[Job](
+              runningJob = job,
+              retry = OptionT
+                .fromOption[F](job.id)
+                .semiflatMap(id => jobsClient.get(project.value, id))
+                .value
+            )
+            .flatMap {
+              case BQPoll.Failed(error) => F.raiseError[Option[Job]](error)
+              case BQPoll.Success(job) => F.pure(job.some)
+            }
+            .guaranteeCase {
+              case Outcome.Errored(e) =>
+                logger.warn(e)(show"${job.asJson.noSpaces} failed")
+              case Outcome.Canceled() =>
+                logger.warn(show"${job.asJson.noSpaces} cancelled")
+              case Outcome.Succeeded(_) =>
+                logger.debug(show"${job.asJson.noSpaces} succeeded")
+            }
+        case None => F.pure(None)
+      }
+    }
+
+    freshJobReference(jobId).flatMap(run)
+  }
+
+  override def createTempTable[Param](
+      table: BQTableDef.Table[Param],
+      tmpDataset: BQDataset.Ref,
+      expirationDuration: Option[FiniteDuration]): F[BQTableDef.Table[Param]] =
+    F.delay(
+      table.copy(tableId = BQTableId(
+        tmpDataset,
+        table.tableId.tableName + UUID.randomUUID().toString
+      )))
+      .flatMap { tmp =>
+        val duration = expirationDuration.getOrElse(1.hour)
+        Clock[F].realTime.map(realtime => realtime + duration).flatMap { exp =>
+          val converted = TableHelper
+            .toGoogle(tmp, None)
+            .copy(expirationTime = Some(exp))
+          tableClient
+            .insert(table.tableId.dataset.project.value, table.tableId.dataset.id)(converted)
+            .as(tmp)
+        }
+      }
+
+  override def createTempTableResource[Param](
+      table: BQTableDef.Table[Param],
+      tmpDataset: BQDataset.Ref): Resource[F, BQTableDef.Table[Param]] =
+    Resource.make(createTempTable(table, tmpDataset))(tmp =>
+      tableClient.delete(tmp.tableId.dataset.project.value, tmp.tableId.dataset.id, tmp.tableId.tableName).void)
+
+  private def loadJson[A: Encoder](
+      id: BQJobId,
+      tableId: BQTableId,
+      schema: BQSchema,
+      stream: fs2.Stream[F, A],
+      writeDisposition: WriteDisposition,
+      logStream: Boolean,
+      chunkSize: Int
+  ): F[Option[BQJobStatistics.Load]] = {
+    val submitted = submitJob(id) { ref =>
+      val jobSpec = Job(
+        jobReference = Some(ref),
+        configuration = Some(
+          JobConfiguration(
+            labels = Some(id.labels.value),
+            jobType = Some("LOAD"),
+            load = Some(JobConfigurationLoad(
+              destinationTable = Some(TableHelper.toTableReference(tableId)),
+              sourceUris = Some(Nil),
+              schema = Some(SchemaHelper.toTableSchema(schema)),
+              writeDisposition = Some(writeDisposition.name),
+              sourceFormat = Some("NEWLINE_DELIMITED_JSON")
+            ))
+          ))
+      )
+      resumableUploadUri(jobSpec).flatMap(uri => upload(uri, stream, logStream, chunkSize))
+    }
+    def toJobStats(job: Job) =
+      for {
+        id <- JobHelper.jobId(job)
+        stats <- job.statistics
+        lstats <- JobHelper.toLoadStats(id, stats)
+      } yield lstats
+
+    OptionT(submitted).subflatMap(toJobStats).value
+  }
+
+  private def freshJobReference(id: BQJobId): F[JobReference] = {
+    val withDefaults = id.withDefaults(Some(defaults))
+
+    F.delay(
+      JobReference(
+        jobId = Some(s"${withDefaults.name}-${UUID.randomUUID}"),
+        location = withDefaults.locationId.map(_.value),
+        projectId = Some(withDefaults.projectId.getOrElse(defaults.projectId).value)
+      )
+    )
+  }
+
+  private def resumableUploadUri(job: Job): F[Uri] = {
+    import org.http4s.headers.Location
+
+    client
+      .run(
+        Request[F](
+          method = Method.POST,
+          uri =
+            uri"https://www.googleapis.com/upload/bigquery/v2/projects/jobs".withQueryParam("uploadType", "resumable"))
+          .withEntity(job)
+          .putHeaders("X-Upload-Content-Value" -> "application/octet-stream"))
+      .use(res =>
+        res.headers.get[Location] match {
+          case Some(value) => F.pure(value.uri)
+          case None =>
+            F.raiseError[Uri](
+              new IllegalStateException(
+                s"Not possible to create a upload uri for ${job.asJson.dropNullValues.noSpaces}"))
+        })
+  }
+
+  private def upload[A: Encoder](uri: Uri, stream: Stream[F, A], logStream: Boolean, chunkSize: Int): F[Option[Job]] = {
+    import org.http4s.headers.{Range, `Content-Range`}
+
+    val followRedirects = org.http4s.client.middleware
+      .FollowRedirect(1)(client)
+
+    def uploadChunk(chunk: Chunk[Byte], destOffset: Long): F[(Long, Option[Job])] = {
+      val limit = destOffset + chunk.size
+      val last = chunk.size < chunkSize
+      followRedirects
+        .run(
+          Request[F](uri = uri, method = Method.PUT)
+            .withBodyStream(Stream.chunk(chunk))
+            .putHeaders(
+              `Content-Range`(RangeUnit.Bytes, Range.SubRange(destOffset, limit), if (last) Some(limit) else None)))
+        .use { res =>
+          if (last && res.status == Status.Ok) {
+            res.as[Job].map(x => limit -> x.some)
+          } else F.pure(limit -> none[Job])
+        }
+    }
+
+    stream
+      .through(StreamUtils.toLineSeparatedJsonBytes(chunkSize))
+      .evalMapAccumulate(0L) { case (state, chunk) =>
+        if (logStream) {
+          val msg = List(
+            "uploading",
+            chunk.size.toLong.toString,
+            s"accumulated ${state + chunk.size}"
+          ).mkString(" ")
+          logger.info(msg) >> uploadChunk(chunk, state)
+        } else uploadChunk(chunk, state)
+      }
+      .map(_._2)
+      .unNone
+      .compile
+      .last
+  }
+}
+
+object Http4sQueryClient {
+  def fromClient[F[_]: Async: LoggerFactory](
+      client: Client[F],
+      defaults: BQClientDefaults,
+      pollConfig: QueryClient.PollConfig): Http4sQueryClient[F] =
+    new Http4sQueryClient[F](client, defaults, pollConfig)
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
@@ -212,7 +212,7 @@ class Http4sQueryClient[F[_]] private (
       for {
         id <- JobHelper.jobId(job)
         stats <- job.statistics
-        qstats <- JobHelper.toQueryStats(id, stats)
+        qstats <- JobHelper.toStats(id, stats)
       } yield JobWithStats(job, qstats)
 
     OptionT(submitted)

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
@@ -271,7 +271,7 @@ class Http4sQueryClient[F[_]] private (
                 .fromOption[F](job.jobReference.flatMap(_.jobId))
                 .flatMapF(id =>
                   jobsClient
-                    .get(project.value, id, query = JobsClient.GetGetParams(location = Some(location.value)))
+                    .get(project.value, id, query = JobsClient.GetParams(location = Some(location.value)))
                     .map(_.some)
                     .recoverWith {
                       case err: GoogleError if err.code.contains(Status.NotFound.code) =>

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/Http4sQueryClient.scala
@@ -377,12 +377,17 @@ class Http4sQueryClient[F[_]] private (
 
   private def resumableUploadUri(projectId: ProjectId, job: Job): F[Uri] = {
     import org.http4s.headers.Location
+    val uploadUri = {
+      val base = jobsClient.baseUri
+      base.withPath(path"/upload".addSegments(base.path.segments)) / "projects"
+    }
 
     client
       .run(
         Request[F](
+          httpVersion = HttpVersion.`HTTP/2`,
           method = Method.POST,
-          uri = (uri"https://bigquery.googleapis.com/upload/bigquery/v2/projects" / projectId.value / "jobs")
+          uri = (uploadUri / projectId.value / "jobs")
             .withQueryParam("uploadType", "resumable")
         )
           .withEntity(job)

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/Http4sBQPollImpl.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/Http4sBQPollImpl.scala
@@ -14,9 +14,6 @@ private[client] object Http4sBQPollImpl {
     override def reference(job: Job): BQJobId =
       JobHelper.jobId(job).getOrElse(throw new IllegalStateException("Unable to get id from job"))
 
-    override def id(job: Job): Option[String] =
-      job.id
-
     override def toPoll(job: Job): BQPoll = {
       val maybeStatus: Option[JobStatus] = job.status
 

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/Http4sBQPollImpl.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/Http4sBQPollImpl.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.client.http4s.internal
+
+import googleapis.bigquery.{Job, JobStatus}
+import no.nrk.bigquery.*
+
+private[client] object Http4sBQPollImpl {
+  implicit val instance: BQPoll.FromJob[Job] = new BQPoll.FromJob[Job] {
+    override def reference(job: Job): BQJobId =
+      JobHelper.jobId(job).getOrElse(throw new IllegalStateException("Unable to get id from job"))
+
+    override def id(job: Job): Option[String] =
+      job.id
+
+    override def toPoll(job: Job): BQPoll = {
+      val maybeStatus: Option[JobStatus] = job.status
+
+      val maybeFailed: Option[BQPoll.Failed] =
+        maybeStatus.flatMap { (s: JobStatus) =>
+          val primary = s.errorResult.map(proto => BQError(proto.location, proto.message, proto.reason))
+
+          val details = s.errors.getOrElse(Nil).map(proto => BQError(proto.location, proto.message, proto.reason))
+
+          if (primary.isEmpty && details.isEmpty) None
+          else Some(BQPoll.Failed(BQExecutionException(reference(job), primary, details)))
+        }
+
+      maybeFailed.getOrElse {
+        maybeStatus match {
+          case Some(status) =>
+            status.state match {
+              case Some("DONE") => BQPoll.Success(job)
+              case Some("PENDING") => BQPoll.Pending
+              case Some("RUNNING") => BQPoll.Running
+              case _ => BQPoll.Unknown
+            }
+          case None => BQPoll.Unknown
+        }
+      }
+    }
+  }
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/JobHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/JobHelper.scala
@@ -23,6 +23,9 @@ object JobHelper {
           JobLabels.unsafeFrom(job.configuration.flatMap(_.labels).getOrElse(Map.empty).toList*)
         ))
 
+  def toStats(jobId: BQJobId, stat: JobStatistics): Option[BQJobStatistics] =
+    toQueryStats(jobId, stat).orElse(toLoadStats(jobId, stat))
+
   def toQueryStats(jobId: BQJobId, stat: JobStatistics) =
     stat.query.map(qstat =>
       BQJobStatistics.Query(

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/JobHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/JobHelper.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery
+package client.http4s
+package internal
+
+import googleapis.bigquery.{Job, JobStatistics}
+
+import java.time.Instant
+
+object JobHelper {
+  def jobId(job: Job) =
+    job.jobReference
+      .map(ref =>
+        BQJobId(
+          ref.projectId.map(ProjectId.unsafeFromString),
+          ref.location.map(LocationId.apply),
+          ref.jobId.getOrElse(""),
+          JobLabels.unsafeFrom(job.configuration.flatMap(_.labels).getOrElse(Map.empty).toList*)
+        ))
+
+  def toQueryStats(jobId: BQJobId, stat: JobStatistics) =
+    stat.query.map(qstat =>
+      BQJobStatistics.Query(
+        jobId,
+        stat.creationTime.map(dur => Instant.ofEpochMilli(dur.toMillis)),
+        stat.startTime.map(dur => Instant.ofEpochMilli(dur.toMillis)),
+        stat.endTime.map(dur => Instant.ofEpochMilli(dur.toMillis)),
+        stat.numChildJobs.getOrElse(0L),
+        stat.parentJobId,
+        qstat.schema.map(SchemaHelper.fromTableSchema),
+        qstat.billingTier,
+        qstat.estimatedBytesProcessed,
+        qstat.numDmlAffectedRows,
+        qstat.totalBytesBilled,
+        qstat.totalBytesProcessed,
+        qstat.totalPartitionsProcessed,
+        qstat.totalSlotMs.map(_.toMillis)
+      ))
+
+  def toLoadStats(jobId: BQJobId, stat: JobStatistics) =
+    stat.load.map(lstat =>
+      BQJobStatistics.Load(
+        jobId,
+        stat.creationTime.map(dur => Instant.ofEpochMilli(dur.toMillis)),
+        stat.startTime.map(dur => Instant.ofEpochMilli(dur.toMillis)),
+        stat.endTime.map(dur => Instant.ofEpochMilli(dur.toMillis)),
+        stat.numChildJobs.getOrElse(0L),
+        stat.parentJobId,
+        lstat.inputFileBytes,
+        lstat.inputFiles,
+        lstat.outputBytes,
+        lstat.outputRows,
+        lstat.badRecords
+      ))
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/RoutineHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/RoutineHelper.scala
@@ -48,7 +48,7 @@ object RoutineHelper {
           description = description
         )
 
-      case UDF.Persistent(name, params, body, returnType) =>
+      case UDF.Persistent(name, params, body, returnType, description) =>
         val (lang, bodyString, imports) = body match {
           case UDF.Body.Sql(bd) => (RoutineLanguage.SQL, bd.asString, None)
           case UDF.Body.Js(bd, imports) => (RoutineLanguage.JAVASCRIPT, bd, Some(imports))
@@ -71,7 +71,8 @@ object RoutineHelper {
               .toList),
           definitionBody = Some(bodyString),
           importedLibraries = imports,
-          returnType = returnType.map(SchemaHelper.fromBQType)
+          returnType = returnType.map(SchemaHelper.fromBQType),
+          description = description
         )
     }
 
@@ -106,7 +107,8 @@ object RoutineHelper {
       id,
       ToSized(params),
       body,
-      routine.returnType.flatMap(SchemaHelper.toBQType)
+      routine.returnType.flatMap(SchemaHelper.toBQType),
+      routine.description
     )
 
   def toTVF(routine: Routine, ref: RoutineReference) =

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/RoutineHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/RoutineHelper.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery
+package client.http4s.internal
+
+import cats.syntax.all.*
+import googleapis.bigquery.*
+import no.nrk.bigquery.util.ToSized
+
+object RoutineHelper {
+  def fromGoogle(routine: Routine): Either[String, BQPersistentRoutine.Unknown] =
+    for {
+      ref <- routine.routineReference.toRight("No routine reference defined")
+      tpe <- routine.routineType.toRight("No routine type defined")
+      converted <- tpe match {
+        case RoutineRoutineType.SCALAR_FUNCTION => toUDF(routine, ref)
+        case RoutineRoutineType.TABLE_VALUED_FUNCTION => toTVF(routine, ref)
+        case x => Left(s"routine type '${x.value}' is not supported")
+      }
+
+    } yield converted
+
+  def toGoogle(routine: BQPersistentRoutine.Unknown, existing: Option[Routine]) =
+    routine match {
+      case TVF(name, _, params, query, schema, description) =>
+        val patching = existing.getOrElse(
+          Routine(
+            routineReference = Some(
+              RoutineReference(
+                projectId = Some(name.dataset.project.value),
+                datasetId = Some(name.dataset.id),
+                routineId = Some(name.name.value))),
+            language = Some(RoutineLanguage.SQL),
+            routineType = Some(RoutineRoutineType.TABLE_VALUED_FUNCTION)
+          ))
+
+        patching.copy(
+          arguments = Some(
+            params.unsized
+              .map(p => Argument(name = Some(p.name.value), dataType = p.maybeType.map(SchemaHelper.fromBQType)))
+              .toList),
+          definitionBody = Some(query.asString),
+          returnTableType = Some(SchemaHelper.toTableType(schema)),
+          description = description
+        )
+
+      case UDF.Persistent(name, params, body, returnType) =>
+        val (lang, bodyString, imports) = body match {
+          case UDF.Body.Sql(bd) => (RoutineLanguage.SQL, bd.asString, None)
+          case UDF.Body.Js(bd, imports) => (RoutineLanguage.JAVASCRIPT, bd, Some(imports))
+        }
+        val patching = existing.getOrElse(
+          Routine(
+            routineReference = Some(
+              RoutineReference(
+                projectId = Some(name.dataset.project.value),
+                datasetId = Some(name.dataset.id),
+                routineId = Some(name.name.value))),
+            language = Some(lang),
+            routineType = Some(RoutineRoutineType.SCALAR_FUNCTION)
+          ))
+
+        patching.copy(
+          arguments = Some(
+            params.unsized
+              .map(p => Argument(name = Some(p.name.value), dataType = p.maybeType.map(SchemaHelper.fromBQType)))
+              .toList),
+          definitionBody = Some(bodyString),
+          importedLibraries = imports,
+          returnType = returnType.map(SchemaHelper.fromBQType)
+        )
+    }
+
+  def toUdfId(ref: RoutineReference) =
+    (ref.projectId, ref.datasetId, ref.routineId).mapN((a, b, c) =>
+      UDF.UDFId.PersistentId(BQDataset.Ref(ProjectId.unsafeFromString(a), b), Ident(c)))
+
+  def toTVFId(ref: RoutineReference) =
+    (ref.projectId, ref.datasetId, ref.routineId).mapN((a, b, c) =>
+      TVF.TVFId(BQDataset.Ref(ProjectId.unsafeFromString(a), b), Ident(c)))
+
+  def toParam(argument: Argument) =
+    (argument.name, argument.dataType).mapN((name, dt) => BQRoutine.Param(Ident(name), SchemaHelper.toBQType(dt)))
+
+  def toUDF(routine: Routine, ref: RoutineReference) =
+    for {
+      id <- toUdfId(ref).toRight("Not possible to create UDF.UDFId.PersistentId")
+      params = routine.arguments.getOrElse(Nil).flatMap(toParam)
+      lang <- routine.language.toRight("No language defined")
+      body <- lang match {
+        case RoutineLanguage.SQL =>
+          Right(UDF.Body.Sql(routine.definitionBody.map(BQSqlFrag.Frag.apply).getOrElse(BQSqlFrag.Empty)))
+        case RoutineLanguage.JAVASCRIPT =>
+          Right(
+            UDF.Body.Js(
+              routine.definitionBody.getOrElse(""),
+              routine.importedLibraries.getOrElse(Nil)
+            ))
+        case x => Left(s"Unsupported language: '$x'")
+      }
+    } yield UDF.Persistent(
+      id,
+      ToSized(params),
+      body,
+      routine.returnType.flatMap(SchemaHelper.toBQType)
+    )
+
+  def toTVF(routine: Routine, ref: RoutineReference) =
+    for {
+      id <- toTVFId(ref).toRight("Not possible to create TVF.TVFId")
+      params = routine.arguments.getOrElse(Nil).flatMap(toParam)
+    } yield TVF(
+      id,
+      BQPartitionType.NotPartitioned,
+      ToSized(params),
+      routine.definitionBody.map(BQSqlFrag.Frag.apply).getOrElse(BQSqlFrag.Empty),
+      routine.returnTableType.flatMap(SchemaHelper.fromTableType).getOrElse(BQSchema.of())
+    )
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/SchemaHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/SchemaHelper.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery
+package client.http4s.internal
+
+import cats.syntax.all.*
+import googleapis.bigquery.*
+
+object SchemaHelper {
+  def fromTableSchema(schema: TableSchema) =
+    BQSchema(fields = schema.fields.getOrElse(Nil).map(fromTableFieldSchema))
+
+  def fromTableFieldSchema(field: TableFieldSchema): BQField =
+    field match {
+      case TableFieldSchema(Some(name), _, _, _, tags, desc, _, subFields, _, mode, Some(typ), _, _, _) =>
+        BQField(
+          name = name,
+          tpe = BQField.Type.unsafeFromString(typ match {
+            case "RECORD" => "STRUCT"
+            case "INTEGER" => "INT64"
+            case "FLOAT" => "FLOAT64"
+            case x => x
+          }),
+          mode = mode.map(BQField.Mode.unsafeFromString).getOrElse(BQField.Mode.NULLABLE),
+          subFields = subFields.getOrElse(Nil).map(fromTableFieldSchema),
+          description = desc,
+          policyTags = tags.flatMap(_.names).getOrElse(Nil)
+        )
+      case _ => sys.error(s"Unable to convert $field")
+    }
+
+  def toTableSchema(schema: BQSchema) =
+    TableSchema(fields = Some(schema.fields.map(toTableFieldSchema)))
+
+  def toTableFieldSchema(field: BQField): TableFieldSchema =
+    field match {
+      case BQField(name, typ, mode, desc, subFields, tags) =>
+        TableFieldSchema(
+          name = Some(name),
+          `type` = Some(typ.name),
+          mode = Some(mode.name),
+          fields = if (subFields.nonEmpty) Some(subFields.map(toTableFieldSchema)) else None,
+          description = desc,
+          policyTags = if (tags.nonEmpty) Some(TableFieldSchemaPolicyTags(Some(tags))) else None
+        )
+    }
+
+  def toBQFieldTuple(field: StandardSqlField) =
+    (field.name, field.`type`).flatMapN((name, t) => toBQType(t).map(name -> _))
+
+  def toBQType(tpe: StandardSqlDataType): Option[BQType] = {
+    val kind = tpe.typeKind.get
+    kind match {
+      case StandardSqlDataTypeTypeKind.INT64 => Some(BQType.INT64)
+      case StandardSqlDataTypeTypeKind.BOOL => Some(BQType.BOOL)
+      case StandardSqlDataTypeTypeKind.FLOAT64 => Some(BQType.FLOAT64)
+      case StandardSqlDataTypeTypeKind.STRING => Some(BQType.STRING)
+      case StandardSqlDataTypeTypeKind.BYTES => Some(BQType.BYTES)
+      case StandardSqlDataTypeTypeKind.TIMESTAMP => Some(BQType.TIMESTAMP)
+      case StandardSqlDataTypeTypeKind.DATE => Some(BQType.DATE)
+      case StandardSqlDataTypeTypeKind.TIME => Some(BQType.TIME)
+      case StandardSqlDataTypeTypeKind.DATETIME => Some(BQType.DATETIME)
+      case StandardSqlDataTypeTypeKind.INTERVAL => Some(BQType.INTERVAL)
+      case StandardSqlDataTypeTypeKind.GEOGRAPHY => Some(BQType.GEOGRAPHY)
+      case StandardSqlDataTypeTypeKind.NUMERIC => Some(BQType.NUMERIC)
+      case StandardSqlDataTypeTypeKind.BIGNUMERIC => Some(BQType.BIGNUMERIC)
+      case StandardSqlDataTypeTypeKind.JSON => Some(BQType.JSON)
+      case StandardSqlDataTypeTypeKind.ARRAY =>
+        tpe.arrayElementType.flatMap(toBQType).map(inner => BQType(BQField.Mode.REPEATED, inner.tpe, Nil))
+      case StandardSqlDataTypeTypeKind.STRUCT =>
+        tpe.structType.map(struct => BQType.struct(struct.fields.getOrElse(Nil).flatMap(toBQFieldTuple)*))
+      case _ => None
+    }
+  }
+
+  def fromFieldType(tpe: BQField.Type) =
+    tpe match {
+      case BQField.Type.BOOL => Some(StandardSqlDataTypeTypeKind.BOOL)
+      case BQField.Type.INT64 => Some(StandardSqlDataTypeTypeKind.INT64)
+      case BQField.Type.FLOAT64 => Some(StandardSqlDataTypeTypeKind.FLOAT64)
+      case BQField.Type.NUMERIC => Some(StandardSqlDataTypeTypeKind.NUMERIC)
+      case BQField.Type.BIGNUMERIC => Some(StandardSqlDataTypeTypeKind.BIGNUMERIC)
+      case BQField.Type.STRING => Some(StandardSqlDataTypeTypeKind.STRING)
+      case BQField.Type.BYTES => Some(StandardSqlDataTypeTypeKind.BYTES)
+      case BQField.Type.TIMESTAMP => Some(StandardSqlDataTypeTypeKind.TIMESTAMP)
+      case BQField.Type.DATE => Some(StandardSqlDataTypeTypeKind.DATE)
+      case BQField.Type.TIME => Some(StandardSqlDataTypeTypeKind.TIME)
+      case BQField.Type.DATETIME => Some(StandardSqlDataTypeTypeKind.DATETIME)
+      case BQField.Type.GEOGRAPHY => Some(StandardSqlDataTypeTypeKind.GEOGRAPHY)
+      case BQField.Type.JSON => Some(StandardSqlDataTypeTypeKind.JSON)
+      case BQField.Type.INTERVAL => Some(StandardSqlDataTypeTypeKind.INTERVAL)
+      case BQField.Type.STRUCT => None
+      case BQField.Type.ARRAY => None
+      case BQField.Type.RANGE => None
+    }
+
+  def fromBQType(_tpe: BQType): StandardSqlDataType =
+    _tpe match {
+      case BQType(BQField.Mode.REPEATED, tpe, subFields) =>
+        StandardSqlDataType(
+          arrayElementType = Some(fromBQType(BQType(BQField.Mode.NULLABLE, tpe, subFields))),
+          typeKind = Some(StandardSqlDataTypeTypeKind.ARRAY))
+      case BQType(_, BQField.Type.STRUCT, subFields) =>
+        StandardSqlDataType(
+          structType = Some(StandardSqlStructType(Some(subFields.map { case (name, typ) =>
+            StandardSqlField(Some(name), Some(fromBQType(typ)))
+          }))),
+          typeKind = Some(StandardSqlDataTypeTypeKind.STRUCT)
+        )
+      case BQType(_, typ, _) =>
+        StandardSqlDataType(typeKind = fromFieldType(typ))
+    }
+
+  def fromTableType(tpe: StandardSqlTableType) = {
+    val cols = tpe.columns.getOrElse(Nil)
+    BQType.struct(cols.flatMap(toBQFieldTuple)*).asSchema.toOption
+  }
+
+  def toTableType(schema: BQSchema): StandardSqlTableType =
+    StandardSqlTableType(
+      Some(schema.fields.map(f => StandardSqlField(Some(f.name), Some(fromBQType(BQType.fromField(f)))))))
+
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/TableHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/TableHelper.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery
+package client.http4s.internal
+
+import cats.syntax.all.*
+import googleapis.bigquery.*
+
+import scala.collection.immutable.SortedMap
+
+object TableHelper {
+  def toTableReference(tableId: BQTableId) =
+    TableReference(Some(tableId.dataset.project.value), Some(tableId.dataset.id), Some(tableId.tableName))
+
+  def fromTableReference(ref: TableReference) =
+    (ref.projectId, ref.datasetId, ref.tableId).mapN((p, d, t) => s"$p.$d.$t").flatMap(BQTableId.fromString(_).toOption)
+
+  def fromGoogle(table: Table): Either[String, BQTableDef[Any]] =
+    for {
+      ref <- table.tableReference.flatMap(fromTableReference).toRight("No table reference provided")
+      table <- table.`type` match {
+        case Some("TABLE") | None => toTable(table, ref)
+        case Some("VIEW") => toView(table, ref)
+        case Some("MATERIALIZED_VIEW") => toMaterializedView(table, ref)
+        case x => Left(s"'${x.getOrElse("UNKNOWN")}' is not supported")
+      }
+    } yield table
+
+  def refFromGoogle(table: TableListTable): Either[String, BQTableRef[Any]] =
+    for {
+      ref <- table.tableReference.flatMap(fromTableReference).toRight("No table reference provided")
+      convert = Table(timePartitioning = table.timePartitioning, rangePartitioning = table.rangePartitioning)
+      partitionType <- extractPartitionFrom(convert)
+    } yield BQTableRef(
+      tableId = ref,
+      partitionType = partitionType,
+      labels = TableLabels(SortedMap.from(table.labels.getOrElse(Map.empty[String, String])))
+    )
+
+  def fromPartition(partitionType: BQPartitionType[Any], tableOptions: TableOptions) =
+    partitionType match {
+      case BQPartitionType.HourPartitioned(field) =>
+        Some(
+          TimePartitioning(
+            expirationMs = tableOptions.partitionExpiration,
+            field = Some(field.value),
+            requirePartitionFilter = Some(tableOptions.partitionFilterRequired),
+            `type` = Some("HOUR")
+          )) -> None
+      case BQPartitionType.DatePartitioned(field) =>
+        Some(
+          TimePartitioning(
+            expirationMs = tableOptions.partitionExpiration,
+            field = Some(field.value),
+            requirePartitionFilter = Some(tableOptions.partitionFilterRequired),
+            `type` = Some("DAY")
+          )) -> None
+      case BQPartitionType.MonthPartitioned(field) =>
+        Some(
+          TimePartitioning(
+            expirationMs = tableOptions.partitionExpiration,
+            field = Some(field.value),
+            requirePartitionFilter = Some(tableOptions.partitionFilterRequired),
+            `type` = Some("MONTH")
+          )) -> None
+      case BQPartitionType.IntegerRangePartitioned(field, range) =>
+        (
+          None,
+          Some(
+            RangePartitioning(
+              Some(field.value),
+              Some(
+                RangePartitioningRange(
+                  end = Some(range.end),
+                  interval = Some(range.interval),
+                  start = Some(range.start))))
+          ))
+      case _ => (None, None)
+    }
+
+  def toGoogle(table: BQTableDef[Any], existing: Option[Table]) = {
+    val t = existing.getOrElse(Table(tableReference = Some(toTableReference(table.tableId))))
+    val existingTableLabels = t.labels.getOrElse(Map.empty)
+    val updatedLabels = existingTableLabels ++ table.labels.values
+
+    table match {
+      case BQTableDef.Table(_, schema, partitionType, description, clustering, _, tableOptions) =>
+        val (time, range) = fromPartition(partitionType, tableOptions)
+
+        val updated = time
+          .map(tm => t.copy(timePartitioning = Some(tm)))
+          .orElse(range.map(r => t.copy(rangePartitioning = Some(r))))
+          .getOrElse(t)
+
+        updated.copy(
+          description = description,
+          clustering = Option.when(clustering.nonEmpty)(Clustering(Some(clustering.map(_.value)))),
+          schema = Some(SchemaHelper.toTableSchema(schema)),
+          labels = Some(existingTableLabels ++ updatedLabels)
+        )
+
+      case BQTableDef.View(_, _, query, schema, description, _) =>
+        t.copy(
+          description = description,
+          view = Some(ViewDefinition(None, Some(false), Some(query.asString), None, None)),
+          schema = Option.when(schema.fields.nonEmpty)(SchemaHelper.toTableSchema(schema)),
+          labels = Some(updatedLabels)
+        )
+
+      case BQTableDef.MaterializedView(
+            _,
+            partitionType,
+            query,
+            schema,
+            enableRefresh,
+            refreshIntervalMs,
+            description,
+            _,
+            tableOptions) =>
+        val (time, range) = fromPartition(partitionType, tableOptions)
+
+        val updated = time
+          .map(tm => t.copy(timePartitioning = Some(tm)))
+          .orElse(range.map(r => t.copy(rangePartitioning = Some(r))))
+          .getOrElse(t)
+
+        updated.copy(
+          description = description,
+          materializedView = Some(value = MaterializedViewDefinition(
+            query = Some(query.asString),
+            enableRefresh = Some(enableRefresh),
+            refreshIntervalMs = Some(refreshIntervalMs))),
+          schema = Option.when(schema.fields.nonEmpty)(SchemaHelper.toTableSchema(schema)),
+          labels = Some(updatedLabels)
+        )
+    }
+
+  }
+
+  def toPartition(range: RangePartitioning): Either[String, Option[BQPartitionType[Any]]] =
+    (range.range, range.field.map(Ident.apply)).tupled match {
+      case None => Right(None)
+      case Some((RangePartitioningRange(Some(end), Some(interval), Some(start)), field)) =>
+        Right(Some(BQPartitionType.IntegerRangePartitioned(field, BQIntegerRange(start, end, interval))))
+      case Some((x, field)) => Left(s"Unsupported '$x' partitioning on field(${field.value})")
+    }
+
+  def toPartition(time: TimePartitioning): Either[String, Option[BQPartitionType[Any]]] =
+    (time.`type`, time.field.map(Ident.apply)).tupled match {
+      case None => Right(None)
+      case Some(("DAY", field)) => Right(Some(BQPartitionType.DatePartitioned(field)))
+      case Some(("HOUR", field)) => Right(Some(BQPartitionType.HourPartitioned(field)))
+      case Some(("MONTH", field)) => Right(Some(BQPartitionType.MonthPartitioned(field)))
+      case Some((x, field)) => Left(s"Unsupported '$x' partitioning on field(${field.value})")
+    }
+
+  def extractPartitionFrom(table: Table): Either[String, BQPartitionType[Any]] =
+    table.timePartitioning.map(toPartition).orElse(table.rangePartitioning.map(toPartition)) match {
+      case Some(value) =>
+        value.flatMap {
+          case None => "Unable to determine partitionType".asLeft[BQPartitionType[Any]]
+          case Some(x) => x.asRight[String]
+        }
+      case None => Right(BQPartitionType.NotPartitioned)
+    }
+
+  private def toTable(table: Table, id: BQTableId) =
+    for {
+      schema <- table.schema.map(SchemaHelper.fromTableSchema).toRight("No schema provided")
+      partitionType <- extractPartitionFrom(table)
+    } yield BQTableDef.Table(
+      id,
+      schema,
+      partitionType,
+      table.description,
+      table.clustering.flatMap(_.fields).getOrElse(Nil).map(Ident.apply),
+      labels = TableLabels.apply(SortedMap.from(table.labels.getOrElse(Map.empty))),
+      tableOptions =
+        TableOptions(table.requirePartitionFilter.getOrElse(false), table.timePartitioning.flatMap(_.expirationMs))
+    )
+  private def toView(table: Table, id: BQTableId) =
+    for {
+      schema <- table.schema.map(SchemaHelper.fromTableSchema).toRight("No schema provided")
+      partitionType = BQPartitionType.NotPartitioned
+    } yield BQTableDef.View(
+      tableId = id,
+      partitionType = partitionType,
+      schema = schema,
+      query = table.view.flatMap(_.query).map(BQSqlFrag.Frag.apply).getOrElse(BQSqlFrag.Empty),
+      description = table.description,
+      labels = TableLabels.apply(SortedMap.from(table.labels.getOrElse(Map.empty)))
+    )
+
+  private def toMaterializedView(table: Table, id: BQTableId) =
+    for {
+      schema <- table.schema.map(SchemaHelper.fromTableSchema).toRight("No schema provided")
+      partitionType = BQPartitionType.NotPartitioned
+    } yield BQTableDef.MaterializedView(
+      tableId = id,
+      partitionType = partitionType,
+      query = table.materializedView.flatMap(_.query).map(BQSqlFrag.Frag.apply).getOrElse(BQSqlFrag.Empty),
+      schema = schema,
+      description = table.description,
+      refreshIntervalMs = table.materializedView.flatMap(_.refreshIntervalMs).getOrElse(1800000L),
+      enableRefresh = table.materializedView.flatMap(_.enableRefresh).getOrElse(true),
+      labels = TableLabels.apply(SortedMap.from(table.labels.getOrElse(Map.empty))),
+      tableOptions =
+        TableOptions(table.requirePartitionFilter.getOrElse(false), table.timePartitioning.flatMap(_.expirationMs))
+    )
+}

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/TableHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/TableHelper.scala
@@ -14,7 +14,10 @@ import scala.collection.immutable.SortedMap
 
 object TableHelper {
   def toTableReference(tableId: BQTableId) =
-    TableReference(Some(tableId.dataset.project.value), Some(tableId.dataset.id), Some(tableId.tableName))
+    TableReference(
+      projectId = Some(tableId.dataset.project.value),
+      datasetId = Some(tableId.dataset.id),
+      tableId = Some(tableId.tableName))
 
   def fromTableReference(ref: TableReference) =
     (ref.projectId, ref.datasetId, ref.tableId).mapN((p, d, t) => s"$p.$d.$t").flatMap(BQTableId.fromString(_).toOption)

--- a/testing/src/test/scala/no/nrk/bigquery/BQReadTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/BQReadTest.scala
@@ -9,7 +9,7 @@ package no.nrk.bigquery
 import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.BQSmokeTest
 
-class BQReadTest extends BQSmokeTest(GoogleTestClient.testClient) {
+class BQReadTest extends BQSmokeTest(Http4sTestClient.testClient) {
   case class Nested(a: String, b: Long)
   object Nested {
     implicit val bqRead: BQRead[Nested] = BQRead.derived

--- a/testing/src/test/scala/no/nrk/bigquery/Http4sTestClient.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/Http4sTestClient.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery
+
+import cats.data.OptionT
+import cats.effect.{IO, Resource}
+import com.permutive.gcp.auth.TokenProvider
+import no.nrk.bigquery.client.http4s.Http4sBigQueryClient
+import org.http4s.netty.client.NettyClientBuilder
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+
+object Http4sTestClient {
+  private implicit val loggerFactory: Slf4jFactory[IO] = Slf4jFactory.create[IO]
+
+  def testClient: Resource[IO, QueryClient[IO]] =
+    for {
+      client <- NettyClientBuilder[IO].withHttp2.resource
+      clientDefaults <- Resource.eval(IO {
+        val project = sys.env
+          .get("BIGQUERY_DEFAULT_PROJECT")
+          .map(ProjectId.unsafeFromString)
+          .getOrElse(ProjectId.unsafeFromString("bigquery-public-data"))
+        val location = sys.env
+          .get("BIGQUERY_DEFAULT_LOCATION")
+          .map(LocationId.apply)
+          .getOrElse(LocationId.US)
+        BQClientDefaults(project, location)
+      })
+      credentials <- Resource.eval(
+        OptionT(IO(sys.env.get("BIGQUERY_SERVICE_ACCOUNT")))
+          .semiflatMap { env =>
+            Http4sBigQueryClient.serviceAccountFromString[IO](env, client)
+          }
+          .getOrElseF(TokenProvider.userAccount[IO](client)))
+
+      underlying <- Http4sBigQueryClient.resource[IO](
+        client,
+        clientDefaults,
+        credentials
+      )
+    } yield underlying
+
+}

--- a/testing/src/test/scala/no/nrk/bigquery/LiveBqUdfSmokeTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/LiveBqUdfSmokeTest.scala
@@ -11,7 +11,7 @@ import no.nrk.bigquery.BQRoutine.{Param, Params}
 import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.BQUdfSmokeTest
 
-class LiveBqUdfSmokeTest extends BQUdfSmokeTest(GoogleTestClient.testClient) {
+class LiveBqUdfSmokeTest extends BQUdfSmokeTest(Http4sTestClient.testClient) {
 
   private val doubleUdf = UDF.temporary(
     Ident("xxdouble_TMP"),

--- a/testing/src/test/scala/no/nrk/bigquery/LiveTempUdfTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/LiveTempUdfTest.scala
@@ -10,7 +10,7 @@ import no.nrk.bigquery.BQRoutine.{Param, Params}
 import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.BQSmokeTest
 
-class LiveTempUdfTest extends BQSmokeTest(GoogleTestClient.testClient) {
+class LiveTempUdfTest extends BQSmokeTest(Http4sTestClient.testClient) {
   val udf1 = UDF.temporary(
     Ident("xxdouble_TMP"),
     Params(Param("input", BQType.INT64)),

--- a/testing/src/test/scala/no/nrk/bigquery/RoundtripTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/RoundtripTest.scala
@@ -23,7 +23,7 @@ class RoundtripTest extends CatsEffectSuite {
 
   def roundtrip[P: BQShow: BQRead](expectedValues: P*): IO[Unit] =
     BigQueryTestClient
-      .cachingClient(BigQueryTestClient.queryCachePath, GoogleTestClient.testClient)
+      .cachingClient(BigQueryTestClient.queryCachePath, Http4sTestClient.testClient)
       .use(
         _.synchronousQuery(
           BQJobId.auto,

--- a/testing/src/test/scala/no/nrk/bigquery/TvfSmokeTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/TvfSmokeTest.scala
@@ -10,7 +10,7 @@ import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.BQSmokeTest
 import no.nrk.bigquery.util.*
 
-class TvfSmokeTest extends BQSmokeTest(GoogleTestClient.testClient) {
+class TvfSmokeTest extends BQSmokeTest(Http4sTestClient.testClient) {
 
   private val schema: BQSchema = BQSchema.of(
     BQField("id", BQField.Type.STRING, BQField.Mode.NULLABLE)


### PR DESCRIPTION
Implements Http4s client

This now works with [http4s-netty-client](https://mvnrepository.com/artifact/org.http4s/http4s-netty-client_3/0.5.14), so you should add that as a dependency when using bigquery-http4s

