### PR TITLE
Use scala 3 syntax for imports and type constuctors

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,10 @@
 version = 3.7.17
-runner.dialect = scala213
+runner.dialect = Scala213Source3
+runner.dialectOverride.withAllowStarWildcardImport = true
+runner.dialectOverride.withAllowPostfixStarVarargSplices = true
+runner.dialectOverride.withAllowAsForImportRename = true
+runner.dialectOverride.withAllowQuestionMarkAsTypeWildcard = true
+rewrite.scala3.convertToNewSyntax = true
 style = default
 
 maxColumn = 120
@@ -20,6 +25,7 @@ rewrite.rules = [
 fileOverride {
   "glob:**/scala-3/**/*.scala" {
     runner.dialect = scala3
+    runner.dialectOverride.allowSignificantIndentation = false
   }
 }
 project.excludePaths = ["glob:**/codegen-tests/**/*.scala"]

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.*
 
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
 ThisBuild / tlBaseVersion := "0.16" // your current series x.y
@@ -54,9 +54,9 @@ val commonSettings = Seq(
   scalacOptions -= "-source:3.0-migration",
   scalacOptions ++= {
     if (scalaVersion.value.startsWith("3")) {
-      Seq("-source:3.2-migration")
+      Seq("-source:3.2-migration", "-old-syntax", "-no-indent")
     } else {
-      Seq("-feature", "-language:implicitConversions", "-language:experimental.macros")
+      Nil
     }
   },
   sonatypeProfileName := "no.nrk"

--- a/codegen/src/main/scala/no/nrk/bigquery/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/no/nrk/bigquery/codegen/CodeGen.scala
@@ -12,7 +12,7 @@ import org.apache.commons.text.translate.LookupTranslator
 import java.nio.charset.StandardCharsets
 import java.nio.file.*
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object Generators {
   private val escaper = new LookupTranslator(
@@ -125,9 +125,9 @@ object Generators {
 object CodeGen {
   def generate(tables: immutable.Seq[BQTableDef[Any]], basePackage: List[String]) =
     tables.collect {
-      case table: BQTableDef.Table[_] =>
+      case table: BQTableDef.Table[?] =>
         Source(SourceLocation(table.tableId, basePackage, "Table"), Generators.genTableDef(table))
-      case view: BQTableDef.View[_] =>
+      case view: BQTableDef.View[?] =>
         Source(SourceLocation(view.tableId, basePackage, "View"), Generators.genViewDef(view))
     }
 }

--- a/codegen/src/test/scala/no/nrk/bigquery/codegen/CodeGenTest.scala
+++ b/codegen/src/test/scala/no/nrk/bigquery/codegen/CodeGenTest.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 package codegen
 
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 
 class CodeGenTest extends munit.FunSuite with testing.GeneratedTest {
   val table = BQTableDef.Table(

--- a/core/src/main/scala-2/no/nrk/bigquery/internal/BQLiteralSyntax.scala
+++ b/core/src/main/scala-2/no/nrk/bigquery/internal/BQLiteralSyntax.scala
@@ -28,7 +28,7 @@ object BQLiteralOps {
       Ident.fromString(s).map(_ => c.Expr(q"Ident.unsafeFromString($s)"))
     }
 
-    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Ident] = apply(c)(args: _*)
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Ident] = apply(c)(args*)
   }
 
   object LabelKeyLiteral extends Literally[Labels.Key] {
@@ -38,7 +38,7 @@ object BQLiteralOps {
       Labels.Key.apply(s).toEither.left.map(_.toList.mkString("\n")).map(_ => c.Expr(q"Labels.Key.make($s)"))
     }
 
-    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Labels.Key] = apply(c)(args: _*)
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Labels.Key] = apply(c)(args*)
   }
 
   object LabelValueLiteral extends Literally[Labels.Value] {
@@ -48,7 +48,7 @@ object BQLiteralOps {
       Labels.Value.apply(s).toEither.left.map(_.toList.mkString("\n")).map(_ => c.Expr(q"Labels.Value.make($s)"))
     }
 
-    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Labels.Value] = apply(c)(args: _*)
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Labels.Value] = apply(c)(args*)
   }
 
 }

--- a/core/src/main/scala-3/no/nrk/bigquery/internal/BQLiteralSyntax.scala
+++ b/core/src/main/scala-3/no/nrk/bigquery/internal/BQLiteralSyntax.scala
@@ -11,23 +11,27 @@ import no.nrk.bigquery.{Ident, Labels}
 import org.typelevel.literally.Literally
 
 trait BQLiteralSyntax {
-  extension (inline ctx: StringContext)
+  extension (inline ctx: StringContext) {
     inline def ident(args: Any*): Ident =
       ${ IdentLiteral('ctx, 'args) }
     inline def labelkey(args: Any*): Labels.Key =
       ${ LabelKeyLiteral('ctx, 'args) }
     inline def labelvalue(args: Any*): Labels.Value =
       ${ LabelValueLiteral('ctx, 'args) }
+  }
 }
 
-object IdentLiteral extends Literally[Ident]:
+object IdentLiteral extends Literally[Ident] {
   def validate(s: String)(using Quotes) =
     Ident.fromString(s).map(_ => '{ Ident.unsafeFromString(${ Expr(s) }) })
+}
 
-object LabelKeyLiteral extends Literally[Labels.Key]:
+object LabelKeyLiteral extends Literally[Labels.Key] {
   def validate(s: String)(using Quotes) =
     Labels.Key(s).toEither.left.map(_.toList.mkString("\n")).map(_ => '{ Labels.Key.make(${ Expr(s) }) })
+}
 
-object LabelValueLiteral extends Literally[Labels.Value]:
+object LabelValueLiteral extends Literally[Labels.Value] {
   def validate(s: String)(using Quotes) =
     Labels.Value(s).toEither.left.map(_.toList.mkString("\n")).map(_ => '{ Labels.Value.make(${ Expr(s) }) })
+}

--- a/core/src/main/scala-3/no/nrk/bigquery/util/Sized.scala
+++ b/core/src/main/scala-3/no/nrk/bigquery/util/Sized.scala
@@ -11,7 +11,7 @@ final class Sized[+Repr, N <: Nat](val unsized: Repr) {
 
   override def equals(other: Any): Boolean =
     other match {
-      case o: Sized[_, _] => unsized == o.unsized
+      case o: Sized[?, ?] => unsized == o.unsized
       case _ => false
     }
 
@@ -25,8 +25,9 @@ object Sized {
   def wrap[Repr, L <: Nat](r: Repr): Sized[Repr, L] =
     new Sized[Repr, L](r)
 
-  extension [A, N <: Nat](sized: Sized[IndexedSeq[A], N])
+  extension [A, N <: Nat](sized: Sized[IndexedSeq[A], N]) {
     def map[B](f: A => B): Sized[IndexedSeq[B], N] =
       new Sized[IndexedSeq[B], N](sized.unsized.map(f(_)))
     def length: Int = sized.unsized.length
+  }
 }

--- a/core/src/main/scala/no/nrk/bigquery/BQExecutionException.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQExecutionException.scala
@@ -7,9 +7,9 @@
 package no.nrk.bigquery
 
 import cats.Show
-import cats.syntax.show._
+import cats.syntax.show.*
 import com.google.cloud.bigquery.{BigQueryError, JobId, Jsonify}
-import BQExecutionExceptionInstances._
+import BQExecutionExceptionInstances.*
 
 case class BQExecutionException(
     jobId: JobId,

--- a/core/src/main/scala/no/nrk/bigquery/BQPoll.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQPoll.scala
@@ -7,14 +7,14 @@
 package no.nrk.bigquery
 
 import cats.effect.Async
-import cats.effect.implicits._
-import cats.syntax.all._
+import cats.effect.implicits.*
+import cats.syntax.all.*
 import com.google.cloud.bigquery.{BigQueryError, Job, JobStatus}
 import org.typelevel.log4cats.LoggerFactory
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Random
 
 sealed trait BQPoll

--- a/core/src/main/scala/no/nrk/bigquery/BQRead.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQRead.scala
@@ -11,9 +11,9 @@ import io.circe.Json
 import org.apache.avro.util.Utf8
 import org.apache.avro
 
-import java.time._
-import scala.collection.compat._
-import scala.jdk.CollectionConverters._
+import java.time.*
+import scala.collection.compat.*
+import scala.jdk.CollectionConverters.*
 
 import scala.reflect.ClassTag
 
@@ -72,9 +72,9 @@ object BQRead extends BQReadCompat {
       override def read(transportSchema: avro.Schema, value: Any): I[A] = {
         val b = cb.newBuilder
         value match {
-          case coll: scala.Array[_] =>
+          case coll: scala.Array[?] =>
             coll.foreach(elem => b += BQRead[A].read(transportSchema.getElementType, elem))
-          case coll: java.util.Collection[_] =>
+          case coll: java.util.Collection[?] =>
             coll.forEach(elem => b += BQRead[A].read(transportSchema.getElementType, elem))
           case other =>
             sys.error(
@@ -93,9 +93,9 @@ object BQRead extends BQReadCompat {
       override def read(transportSchema: avro.Schema, value: Any): Array[A] = {
         val b = Array.newBuilder[A]
         value match {
-          case coll: scala.Array[_] =>
+          case coll: scala.Array[?] =>
             coll.foreach(elem => b += BQRead[A].read(transportSchema.getElementType, elem))
-          case coll: java.util.Collection[_] =>
+          case coll: java.util.Collection[?] =>
             coll.forEach(elem => b += BQRead[A].read(transportSchema.getElementType, elem))
           case other =>
             sys.error(

--- a/core/src/main/scala/no/nrk/bigquery/BQShow.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQShow.scala
@@ -62,7 +62,7 @@ object BQShow extends BQShowInstances {
       }
     }
 
-    def bqfr(args: BQSqlFrag.Magnet*): BQSqlFrag = bqsql(args: _*)
+    def bqfr(args: BQSqlFrag.Magnet*): BQSqlFrag = bqsql(args*)
   }
 
 }

--- a/core/src/main/scala/no/nrk/bigquery/BQTableLike.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQTableLike.scala
@@ -6,9 +6,9 @@
 
 package no.nrk.bigquery
 
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import cats.effect.Concurrent
-import cats.syntax.all._
+import cats.syntax.all.*
 import no.nrk.bigquery.util.{Nat, Sized}
 
 /** @tparam P

--- a/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BigQueryClient.scala
@@ -8,10 +8,10 @@ package no.nrk.bigquery
 
 import cats.Show
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.Outcome
 import cats.effect.{Async, Resource}
-import cats.syntax.all._
+import cats.syntax.all.*
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.gax.retrying.RetrySettings
 import com.google.api.gax.rpc.ServerStream
@@ -19,13 +19,13 @@ import com.google.auth.Credentials
 import com.google.cloud.bigquery.BigQuery.{JobOption, TableOption}
 import com.google.cloud.bigquery.JobInfo.WriteDisposition
 import com.google.cloud.bigquery.JobStatistics.LoadStatistics
-import com.google.cloud.bigquery.storage.v1._
-import com.google.cloud.bigquery.{Option => _, _}
+import com.google.cloud.bigquery.storage.v1.*
+import com.google.cloud.bigquery.{Option as _, *}
 import com.google.cloud.http.HttpTransportOptions
 import fs2.{Chunk, Stream}
 import io.circe.Encoder
 import no.nrk.bigquery.internal.{PartitionTypeHelper, SchemaHelper, TableUpdateOperation}
-import no.nrk.bigquery.internal.GoogleTypeHelper._
+import no.nrk.bigquery.internal.GoogleTypeHelper.*
 import no.nrk.bigquery.metrics.{BQMetrics, MetricsOps}
 import no.nrk.bigquery.util.StreamUtils
 import org.apache.avro
@@ -37,8 +37,8 @@ import org.typelevel.log4cats.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 
 class BigQueryClient[F[_]](
     bigQuery: BigQuery,
@@ -130,7 +130,7 @@ class BigQueryClient[F[_]](
       submitJob(jobId)(jobId =>
         F.blocking(
           Option(
-            bigQuery.create(JobInfo.of(jobId, queryRequest), jobOptions: _*)
+            bigQuery.create(JobInfo.of(jobId, queryRequest), jobOptions*)
           )
         )).flatMap {
         case Some(job) => F.pure(job)
@@ -448,7 +448,7 @@ class BigQueryClient[F[_]](
 
       F.interruptible(
         Option(
-          bigQuery.create(JobInfo.of(jobId, jobConfiguration), jobOptions: _*)
+          bigQuery.create(JobInfo.of(jobId, jobConfiguration), jobOptions*)
         )
       )
     }.flatMap {
@@ -505,12 +505,12 @@ class BigQueryClient[F[_]](
       tableOptions: TableOption*
   ): F[Option[Table]] =
     F.interruptible(
-      Option(bigQuery.getTable(tableId.underlying, tableOptions: _*))
+      Option(bigQuery.getTable(tableId.underlying, tableOptions*))
         .filter(_.exists())
     )
 
   def getTableLike(tableId: BQTableId, tableOptions: TableOption*): F[Option[BQTableDef[Any]]] =
-    OptionT(getTable(tableId, tableOptions: _*)).mapFilter(t => SchemaHelper.fromTable(t).toOption).value
+    OptionT(getTable(tableId, tableOptions*)).mapFilter(t => SchemaHelper.fromTable(t).toOption).value
 
   def tableExists(tableId: BQTableId): F[Table] =
     getTable(tableId).flatMap {
@@ -561,7 +561,7 @@ class BigQueryClient[F[_]](
       dataset: BQDataset.Ref,
       datasetOptions: BigQuery.TableListOption*
   ): F[Vector[BQTableRef[Any]]] =
-    F.interruptible(bigQuery.listTables(dataset.underlying, datasetOptions: _*)).flatMap { tables =>
+    F.interruptible(bigQuery.listTables(dataset.underlying, datasetOptions*)).flatMap { tables =>
       tables
         .iterateAll()
         .asScala

--- a/core/src/main/scala/no/nrk/bigquery/EnsureUpdated.scala
+++ b/core/src/main/scala/no/nrk/bigquery/EnsureUpdated.scala
@@ -7,8 +7,8 @@
 package no.nrk.bigquery
 
 import cats.{Applicative, MonadThrow, Show}
-import cats.syntax.all._
-import com.google.cloud.bigquery.{Option => _, _}
+import cats.syntax.all.*
+import com.google.cloud.bigquery.{Option as _, *}
 import no.nrk.bigquery.internal.{RoutineUpdateOperation, TableUpdateOperation}
 import org.typelevel.log4cats.LoggerFactory
 
@@ -23,7 +23,7 @@ case class TableDefOperationMeta(
 }
 case class PersistentRoutineOperationMeta(
     routine: RoutineInfo,
-    persistentRoutine: BQPersistentRoutine[_, _]
+    persistentRoutine: BQPersistentRoutine[?, ?]
 ) extends OperationMeta {
   override def identifier: String = persistentRoutine.name.asString
 }
@@ -56,22 +56,22 @@ object UpdateOperation {
   ) extends Success
 
   case class CreateTvf(
-      tvf: TVF[Any, _],
+      tvf: TVF[Any, ?],
       routine: RoutineInfo
   ) extends Success
 
   case class UpdateTvf(
-      tvf: TVF[Any, _],
+      tvf: TVF[Any, ?],
       routine: RoutineInfo
   ) extends Success
 
   case class CreatePersistentUdf(
-      persistentUdf: UDF.Persistent[_],
+      persistentUdf: UDF.Persistent[?],
       routine: RoutineInfo
   ) extends Success
 
   case class UpdatePersistentUdf(
-      persistentUdf: UDF.Persistent[_],
+      persistentUdf: UDF.Persistent[?],
       routine: RoutineInfo
   ) extends Success
 
@@ -99,7 +99,7 @@ class EnsureUpdated[F[_]](
       TableUpdateOperation.from(template, maybeExisting)
     }
 
-  def check(persistentRoutine: BQPersistentRoutine[_, _]): F[UpdateOperation] =
+  def check(persistentRoutine: BQPersistentRoutine[?, ?]): F[UpdateOperation] =
     bqClient.getRoutine(persistentRoutine.name).map { maybeExisting =>
       RoutineUpdateOperation.from(persistentRoutine, maybeExisting)
     }

--- a/core/src/main/scala/no/nrk/bigquery/Ident.scala
+++ b/core/src/main/scala/no/nrk/bigquery/Ident.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 
 import cats.Show
-import cats.syntax.all._
+import cats.syntax.all.*
 
 import scala.util.matching.Regex
 

--- a/core/src/main/scala/no/nrk/bigquery/JobLabels.scala
+++ b/core/src/main/scala/no/nrk/bigquery/JobLabels.scala
@@ -45,11 +45,11 @@ object JobLabels {
   def from(params: scala.collection.immutable.Seq[(Labels.Key, Labels.Value)]): JobLabels = JobLabels(
     SortedMap(params.map { case (k, v) =>
       k.value -> v.value
-    }: _*))
+    }*))
 
   def apply(params: (Labels.Key, Labels.Value)*): JobLabels = from(params.toList)
 
   def unsafeFrom(params: (String, String)*): JobLabels =
-    validated(SortedMap(params: _*))
+    validated(SortedMap(params*))
       .fold(messages => throw new IllegalArgumentException(messages.toList.mkString("\n")), identity)
 }

--- a/core/src/main/scala/no/nrk/bigquery/TableLabels.scala
+++ b/core/src/main/scala/no/nrk/bigquery/TableLabels.scala
@@ -63,7 +63,7 @@ object TableLabels {
   def from(params: scala.collection.immutable.Seq[(Labels.Key, Labels.Value)]): TableLabels = TableLabels(
     SortedMap(params.map { case (k, v) =>
       k.value -> v.value
-    }: _*))
+    }*))
 
   /* nicer syntax for creating instances */
   def apply(values: (String, String)*): TableLabels =

--- a/core/src/main/scala/no/nrk/bigquery/internal/BQShowSyntax.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/BQShowSyntax.scala
@@ -8,7 +8,7 @@ package no.nrk.bigquery.internal
 
 import no.nrk.bigquery.{BQFill, BQFilledTable, BQShow, BQSqlFrag}
 import cats.Foldable
-import cats.syntax.all._
+import cats.syntax.all.*
 
 import java.time.LocalDate
 

--- a/core/src/main/scala/no/nrk/bigquery/internal/GoogleTypeHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/GoogleTypeHelper.scala
@@ -13,7 +13,7 @@ import no.nrk.bigquery.TableLabels.Empty
 import java.util.concurrent.TimeUnit
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object GoogleTypeHelper {
 
@@ -54,7 +54,7 @@ object GoogleTypeHelper {
 
   def tableLabelsfromTableInfo(tableInfo: TableInfo): TableLabels =
     Option(tableInfo.getLabels) match {
-      case Some(values) => new TableLabels(SortedMap(values.asScala.toList: _*))
+      case Some(values) => new TableLabels(SortedMap(values.asScala.toList*))
       case None => Empty
     }
 }

--- a/core/src/main/scala/no/nrk/bigquery/internal/RoutineSyntax.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/RoutineSyntax.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery.internal
 
 import no.nrk.bigquery.{BQRoutine, BQSqlFrag}
-import no.nrk.bigquery.util.nat._
+import no.nrk.bigquery.util.nat.*
 import no.nrk.bigquery.util.IndexSeqSizedBuilder
 
 trait RoutineSyntax {

--- a/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
@@ -7,16 +7,16 @@
 package no.nrk.bigquery
 package internal
 
-import com.google.cloud.bigquery.{Option => _, _}
+import com.google.cloud.bigquery.{Option as _, *}
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object SchemaHelper {
   def fromType(typ: BQField.Type): StandardSQLTypeName = StandardSQLTypeName.valueOf(typ.name)
   def fromMode(mode: BQField.Mode): Field.Mode = Field.Mode.valueOf(mode.name)
 
   def toSchema(schema: BQSchema): Schema =
-    Schema.of(schema.fields.map(toField): _*)
+    Schema.of(schema.fields.map(toField)*)
 
   sealed trait TableConversionError
   object TableConversionError {
@@ -95,7 +95,7 @@ object SchemaHelper {
     }
 
   def toField(field: BQField): Field = {
-    val b = Field.newBuilder(field.name, fromType(field.tpe), field.subFields.map(toField): _*)
+    val b = Field.newBuilder(field.name, fromType(field.tpe), field.subFields.map(toField)*)
     b.setMode(fromMode(field.mode))
     field.description.foreach(b.setDescription)
     if (field.policyTags.nonEmpty) {

--- a/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
@@ -6,13 +6,13 @@
 
 package no.nrk.bigquery.internal
 
-import com.google.cloud.bigquery.{Option => _, _}
-import no.nrk.bigquery._
+import com.google.cloud.bigquery.{Option as _, *}
+import no.nrk.bigquery.*
 
-import scala.jdk.CollectionConverters._
-import GoogleTypeHelper._
+import scala.jdk.CollectionConverters.*
+import GoogleTypeHelper.*
 import cats.Eq
-import cats.syntax.all._
+import cats.syntax.all.*
 
 object TableUpdateOperation {
 

--- a/core/src/main/scala/no/nrk/bigquery/mergeQuery.scala
+++ b/core/src/main/scala/no/nrk/bigquery/mergeQuery.scala
@@ -6,7 +6,7 @@
 
 package no.nrk.bigquery
 
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 
 import scala.annotation.tailrec
 
@@ -14,7 +14,7 @@ object mergeQuery {
   def into[Pid <: BQPartitionId[Any]](source: Pid, target: Pid, primaryKey: Ident, morePrimaryKeys: Ident*): BQSqlFrag =
     (source.wholeTable, target.wholeTable) match {
       case (from: BQTableDef[Any], to: BQTableDef[Any]) =>
-        into(from, to, primaryKey, morePrimaryKeys *)
+        into(from, to, primaryKey, morePrimaryKeys*)
       case (from, into) =>
         sys.error(s"Cannot merge $from into $into")
     }

--- a/core/src/main/scala/no/nrk/bigquery/metrics/BQMetrics.scala
+++ b/core/src/main/scala/no/nrk/bigquery/metrics/BQMetrics.scala
@@ -8,7 +8,7 @@ package no.nrk.bigquery.metrics
 
 import cats.effect.kernel.Outcome
 import cats.effect.{Clock, Concurrent, Resource}
-import cats.syntax.all._
+import cats.syntax.all.*
 import com.google.cloud.bigquery.{Job, JobStatistics}
 import no.nrk.bigquery.BQJobId
 

--- a/core/src/main/scala/no/nrk/bigquery/util/BqSqlProjection.scala
+++ b/core/src/main/scala/no/nrk/bigquery/util/BqSqlProjection.scala
@@ -6,8 +6,8 @@
 
 package no.nrk.bigquery.util
 
-import no.nrk.bigquery._
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.*
+import no.nrk.bigquery.syntax.*
 
 object BqSqlProjection {
   case class TypedFragment(fragment: BQSqlFrag, tpe: BQField)

--- a/core/src/main/scala/no/nrk/bigquery/util/StreamUtils.scala
+++ b/core/src/main/scala/no/nrk/bigquery/util/StreamUtils.scala
@@ -9,12 +9,12 @@ package util
 
 import cats.Functor
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 
 import fs2.compression.Compression
 import fs2.{Chunk, Pipe}
 import io.circe.Encoder
-import io.circe.syntax._
+import io.circe.syntax.*
 import org.typelevel.log4cats.Logger
 
 object StreamUtils {

--- a/core/src/test/scala/no/nrk/bigquery/BQDatasetTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQDatasetTest.scala
@@ -6,7 +6,7 @@
 
 package no.nrk.bigquery
 
-import org.scalacheck._
+import org.scalacheck.*
 
 class BQDatasetTest extends munit.ScalaCheckSuite {
   val project = ProjectId.unsafeFromString("test-123")

--- a/core/src/test/scala/no/nrk/bigquery/BQFillTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQFillTest.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 
 import munit.FunSuite
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 
 import java.time.LocalDate
 

--- a/core/src/test/scala/no/nrk/bigquery/BQSqlFragTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQSqlFragTest.scala
@@ -6,10 +6,10 @@
 
 package no.nrk.bigquery
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import munit.FunSuite
 import no.nrk.bigquery.BQPartitionType.DatePartitioned
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.BQRoutine.{Param, Params}
 
 import java.time.LocalDate

--- a/core/src/test/scala/no/nrk/bigquery/BQTypeTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/BQTypeTest.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 
 import munit.FunSuite
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 
 class BQTypeTest extends FunSuite {
 

--- a/core/src/test/scala/no/nrk/bigquery/IdentTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/IdentTest.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 
 import munit.FunSuite
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 
 /** Examples from: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#identifier_examples
   */

--- a/core/src/test/scala/no/nrk/bigquery/TVFTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/TVFTest.scala
@@ -6,8 +6,8 @@
 
 package no.nrk.bigquery
 
-import no.nrk.bigquery._
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.*
+import no.nrk.bigquery.syntax.*
 import munit.FunSuite
 
 class TVFTest extends FunSuite {

--- a/core/src/test/scala/no/nrk/bigquery/UDFTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/UDFTest.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 
 import munit.FunSuite
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.util.nat._0
 import no.nrk.bigquery.BQRoutine.{Param, Params}
 

--- a/core/src/test/scala/no/nrk/bigquery/internal/RoutineUpdateOperationTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/internal/RoutineUpdateOperationTest.scala
@@ -9,12 +9,12 @@ package no.nrk.bigquery.internal
 import com.google.cloud.bigquery.{RoutineId, RoutineInfo, StandardSQLDataType, StandardSQLField, StandardSQLTableType}
 import munit.FunSuite
 import no.nrk.bigquery.UpdateOperation.{CreatePersistentUdf, Illegal, UpdatePersistentUdf}
-import no.nrk.bigquery._
+import no.nrk.bigquery.*
 import no.nrk.bigquery.BQRoutine.{Param, Params}
-import no.nrk.bigquery.syntax._
-import no.nrk.bigquery.util.nat._
+import no.nrk.bigquery.syntax.*
+import no.nrk.bigquery.util.nat.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class RoutineUpdateOperationTest extends FunSuite {
 

--- a/core/src/test/scala/no/nrk/bigquery/internal/TableUpdateOperationTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/internal/TableUpdateOperationTest.scala
@@ -7,12 +7,12 @@
 package no.nrk.bigquery.internal
 
 import com.google.cloud.bigquery.TimePartitioning.Type
-import com.google.cloud.bigquery.{Option => _, _}
+import com.google.cloud.bigquery.{Option as _, *}
 import munit.FunSuite
-import no.nrk.bigquery.syntax._
-import no.nrk.bigquery._
-import GoogleTypeHelper._
-import scala.concurrent.duration._
+import no.nrk.bigquery.syntax.*
+import no.nrk.bigquery.*
+import GoogleTypeHelper.*
+import scala.concurrent.duration.*
 
 class TableUpdateOperationTest extends FunSuite {
 

--- a/core/src/test/scala/no/nrk/bigquery/util/BqSqlProjectionTest.scala
+++ b/core/src/test/scala/no/nrk/bigquery/util/BqSqlProjectionTest.scala
@@ -7,8 +7,8 @@
 package no.nrk.bigquery.util
 
 import munit.FunSuite
-import no.nrk.bigquery._
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.*
+import no.nrk.bigquery.syntax.*
 
 class BqSqlProjectionTest extends FunSuite {
 

--- a/prometheus/src/main/scala/no/nrk/bigquery/metrics/Prometheus.scala
+++ b/prometheus/src/main/scala/no/nrk/bigquery/metrics/Prometheus.scala
@@ -9,10 +9,10 @@ package metrics
 
 import cats.data.NonEmptyList
 import cats.effect.{Resource, Sync}
-import cats.syntax.apply._
+import cats.syntax.apply.*
 import com.google.cloud.bigquery.JobStatistics
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics
-import io.prometheus.client._
+import io.prometheus.client.*
 
 object Prometheus {
   def collectorRegistry[F[_]](implicit
@@ -206,7 +206,7 @@ object Prometheus {
       val jobDuration: Resource[F, Histogram] = registerCollector(
         Histogram
           .build()
-          .buckets(jobDurationSecondsHistogramBuckets.toList: _*)
+          .buckets(jobDurationSecondsHistogramBuckets.toList*)
           .name(prefix + "_" + "job_duration_seconds")
           .help("Job Duration in seconds.")
           .labelNames("classifier")

--- a/testing/src/main/scala/no/nrk/bigquery/testing/BQSmokeTest.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/BQSmokeTest.scala
@@ -9,19 +9,19 @@ package testing
 
 import cats.effect.{IO, Resource}
 import cats.effect.kernel.Outcome
-import cats.syntax.alternative._
+import cats.syntax.alternative.*
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics
 import com.google.cloud.bigquery.BigQueryException
 import io.circe.parser.decode
-import io.circe.syntax._
+import io.circe.syntax.*
 import munit.Assertions.{clues, fail}
 import munit.{CatsEffectSuite, Clues, Location}
 import no.nrk.bigquery.UDF.Body
-import no.nrk.bigquery._
+import no.nrk.bigquery.*
 import no.nrk.bigquery.internal.SchemaHelper
 import no.nrk.bigquery.testing.BQSmokeTest.{CheckType, bqCheckFragment}
-import org.typelevel.log4cats.slf4j._
-import no.nrk.bigquery.syntax._
+import org.typelevel.log4cats.slf4j.*
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.util.{IndexSeqSizedBuilder, Nat, Sized}
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 
@@ -219,7 +219,7 @@ abstract class BQSmokeTest(testClient: Resource[IO, BigQueryClient[IO]]) extends
         }
     }
 
-  protected def bqCheckTableValueFunction[N <: Nat](testName: String, tvf: TVF[_, N])(
+  protected def bqCheckTableValueFunction[N <: Nat](testName: String, tvf: TVF[?, N])(
       args: IndexSeqSizedBuilder[BQSqlFrag.Magnet] => Sized[IndexedSeq[BQSqlFrag.Magnet], N]
   )(implicit loc: Location): Unit = {
     val values =

--- a/testing/src/main/scala/no/nrk/bigquery/testing/BQStructuredSql.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/BQStructuredSql.scala
@@ -8,7 +8,7 @@ package no.nrk.bigquery.testing
 
 import com.google.cloud.bigquery.UserDefinedFunction
 import no.nrk.bigquery.UDF.Temporary
-import no.nrk.bigquery._
+import no.nrk.bigquery.*
 
 import scala.collection.mutable
 
@@ -61,7 +61,7 @@ object BQStructuredSql {
 
     val functions: List[UserDefinedFunction] = {
       val fs1 = fullQuery.allReferencedUDFs
-        .collect { case udf: Temporary[_] => UserDefinedFunction.inline(udf.definition.asString) }
+        .collect { case udf: Temporary[?] => UserDefinedFunction.inline(udf.definition.asString) }
       val fs2 = functionSegmentLists.map(segmentList => UserDefinedFunction.inline(segmentList.asString + ";"))
       fs1.toList ++ fs2
     }

--- a/testing/src/main/scala/no/nrk/bigquery/testing/BQUdfSmokeTest.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/BQUdfSmokeTest.scala
@@ -7,15 +7,15 @@
 package no.nrk.bigquery
 package testing
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.effect.{IO, Resource}
 import cats.effect.kernel.Outcome
 import io.circe.Json
 import io.circe.parser.decode
-import io.circe.syntax._
+import io.circe.syntax.*
 import munit.{CatsEffectSuite, Location}
-import no.nrk.bigquery.syntax._
-import org.typelevel.log4cats.slf4j._
+import no.nrk.bigquery.syntax.*
+import org.typelevel.log4cats.slf4j.*
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
@@ -61,9 +61,9 @@ object BQUdfSmokeTest {
       call: BQSqlFrag.Call
   ): BigQueryClient[IO] => IO[Json] = { bqClient =>
     val temporaryUdfCall = call.udf match {
-      case _: UDF.Temporary[_] => call
-      case _: UDF.Reference[_] => call
-      case udf: UDF.Persistent[_] => call.copy(udf = udf.convertToTemporary)
+      case _: UDF.Temporary[?] => call
+      case _: UDF.Reference[?] => call
+      case udf: UDF.Persistent[?] => call.copy(udf = udf.convertToTemporary)
     }
 
     val query = bqfr"SELECT TO_JSON_STRING($temporaryUdfCall)"

--- a/testing/src/main/scala/no/nrk/bigquery/testing/BigQueryTestClient.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/BigQueryTestClient.scala
@@ -9,7 +9,7 @@ package testing
 
 import cats.data.OptionT
 import cats.effect.{IO, Resource}
-import cats.syntax.all._
+import cats.syntax.all.*
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.google.cloud.bigquery.BigQuery.JobOption
 import fs2.Stream
@@ -23,7 +23,7 @@ import org.typelevel.log4cats.slf4j.Slf4jFactory
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
 object BigQueryTestClient {

--- a/testing/src/main/scala/no/nrk/bigquery/testing/CTE.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/CTE.scala
@@ -6,8 +6,8 @@
 
 package no.nrk.bigquery.testing
 
-import no.nrk.bigquery._
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.*
+import no.nrk.bigquery.syntax.*
 
 case class CTE(name: Ident, body: BQSqlFrag) {
   require(body.asString.startsWith("(") && body.asString.endsWith(")"))

--- a/testing/src/main/scala/no/nrk/bigquery/testing/package.scala
+++ b/testing/src/main/scala/no/nrk/bigquery/testing/package.scala
@@ -6,7 +6,7 @@
 
 package no.nrk.bigquery
 
-import cats.syntax.show._
+import cats.syntax.show.*
 import io.circe.{Decoder, Encoder}
 import no.nrk.bigquery
 

--- a/testing/src/test/scala/no/nrk/bigquery/BQReadTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/BQReadTest.scala
@@ -6,7 +6,7 @@
 
 package no.nrk.bigquery
 
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.{BQSmokeTest, BigQueryTestClient}
 
 class BQReadTest extends BQSmokeTest(BigQueryTestClient.testClient) {

--- a/testing/src/test/scala/no/nrk/bigquery/BQStructuredSqlTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/BQStructuredSqlTest.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 
 import munit.{FunSuite, Location}
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.BQStructuredSql.{Segment, SegmentList}
 import no.nrk.bigquery.testing.{BQStructuredSql, CTE, CTEList}
 

--- a/testing/src/test/scala/no/nrk/bigquery/LiveTempUdfTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/LiveTempUdfTest.scala
@@ -7,7 +7,7 @@
 package no.nrk.bigquery
 
 import no.nrk.bigquery.BQRoutine.{Param, Params}
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.{BQSmokeTest, BigQueryTestClient}
 
 class LiveTempUdfTest extends BQSmokeTest(BigQueryTestClient.testClient) {

--- a/testing/src/test/scala/no/nrk/bigquery/RoundtripTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/RoundtripTest.scala
@@ -8,7 +8,7 @@ package no.nrk.bigquery
 
 import cats.effect.IO
 import munit.CatsEffectSuite
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.BigQueryTestClient
 
 import java.time.{Instant, LocalDate, LocalTime}

--- a/testing/src/test/scala/no/nrk/bigquery/TvfSmokeTest.scala
+++ b/testing/src/test/scala/no/nrk/bigquery/TvfSmokeTest.scala
@@ -6,9 +6,9 @@
 
 package no.nrk.bigquery
 
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import no.nrk.bigquery.testing.{BQSmokeTest, BigQueryTestClient}
-import no.nrk.bigquery.util._
+import no.nrk.bigquery.util.*
 
 class TvfSmokeTest extends BQSmokeTest(BigQueryTestClient.testClient) {
 

--- a/transfer-client/src/main/scala/no/nrk/bigquery/BigQueryTransferClient.scala
+++ b/transfer-client/src/main/scala/no/nrk/bigquery/BigQueryTransferClient.scala
@@ -8,16 +8,16 @@ package no.nrk.bigquery
 
 import cats.effect.IO
 import cats.effect.kernel.Resource
-import cats.syntax.traverse._
+import cats.syntax.traverse.*
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
-import com.google.cloud.bigquery.datatransfer.v1._
+import com.google.cloud.bigquery.datatransfer.v1.*
 import com.google.protobuf.{Struct, Value}
 import no.nrk.bigquery.BigQueryTransferClient.{TransferConfigFailed, TransferFailed, TransferStatus, TransferSucceeded}
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class BigQueryTransferClient(transferClient: DataTransferServiceClient) {
   protected lazy val logger = Slf4jFactory.create[IO].getLogger

--- a/zetasql/src/test/scala/no/nrk/bigquery/ZetaTest.scala
+++ b/zetasql/src/test/scala/no/nrk/bigquery/ZetaTest.scala
@@ -6,9 +6,9 @@
 
 package no.nrk.bigquery
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.effect.IO
-import no.nrk.bigquery.syntax._
+import no.nrk.bigquery.syntax.*
 import com.google.zetasql.toolkit.AnalysisException
 
 import java.time.LocalDate


### PR DESCRIPTION
This is supported scala 2 syntax as well now with -Xsource:3 which sbt-typelevel automatically adds.

Now we keep the Scala 2 and Scala 3 versions consistent and do not confuse intellij which actually respects the -Xsource:3 flag.

Extracted from #255