### PR TITLE
Ensure updated backport

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.tools.mima.core.*
 
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.16" // your current series x.y
+ThisBuild / tlBaseVersion := "0.17" // your current series x.y
 
 ThisBuild / organization := "no.nrk.bigquery"
 ThisBuild / organizationName := "NRK"

--- a/core/src/main/scala-2/no/nrk/bigquery/util/NatUnknown.scala
+++ b/core/src/main/scala-2/no/nrk/bigquery/util/NatUnknown.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.util
+
+class NatUnknown extends Nat with Serializable {
+  type N = NatUnknown
+}

--- a/core/src/main/scala-2/no/nrk/bigquery/util/ToSized.scala
+++ b/core/src/main/scala-2/no/nrk/bigquery/util/ToSized.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.util
+
+object ToSized {
+  def apply[A](list: List[A]): Sized[IndexedSeq[A], NatUnknown] =
+    Sized.wrap(list.toIndexedSeq)
+}

--- a/core/src/main/scala-3/no/nrk/bigquery/util/NatImpl.scala
+++ b/core/src/main/scala-3/no/nrk/bigquery/util/NatImpl.scala
@@ -35,3 +35,4 @@ object nat {
   type _21 = 21 with NatImpl
   type _22 = 22 with NatImpl
 }
+final class NatUnknown extends NatImpl

--- a/core/src/main/scala-3/no/nrk/bigquery/util/Sized.scala
+++ b/core/src/main/scala-3/no/nrk/bigquery/util/Sized.scala
@@ -31,3 +31,8 @@ object Sized {
     def length: Int = sized.unsized.length
   }
 }
+
+object ToSized {
+  def apply[A](list: List[A]): Sized[IndexedSeq[A], NatUnknown] =
+    Sized.wrap(list.toIndexedSeq)
+}

--- a/core/src/main/scala/no/nrk/bigquery/BQRoutine.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQRoutine.scala
@@ -25,6 +25,8 @@ sealed trait BQPersistentRoutine[N <: Nat, C] extends BQRoutine[N, C] {
 }
 
 object BQPersistentRoutine {
+  type Unknown = BQPersistentRoutine[?, ?]
+
   trait Id {
     def dataset: BQDataset.Ref
     def name: Ident
@@ -65,6 +67,11 @@ case class TVF[+P, N <: Nat](
     schema: BQSchema,
     description: Option[String] = None
 ) extends BQPersistentRoutine[N, BQSqlFrag.TableRef] {
+  def withParitionType[NewParam](
+      tpe: BQPartitionType[NewParam]
+  ): TVF[NewParam, N] =
+    TVF(name, tpe, params, query, schema, description)
+
   def call(args: Sized[IndexedSeq[BQSqlFrag.Magnet], N]): BQSqlFrag.TableRef =
     BQSqlFrag.TableRef(BQAppliedTableValuedFunction(this, args.map(_.frag)))
 }

--- a/core/src/main/scala/no/nrk/bigquery/TableOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/TableOperation.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery
+
+import com.google.cloud.bigquery.{RoutineInfo, TableInfo}
+
+sealed trait OperationMeta {
+  def identifier: String
+}
+case class TableDefOperationMeta(
+    remote: BQTableDef[Any],
+    local: BQTableDef[Any]
+) extends OperationMeta {
+  def identifier: String = local.tableId.asString
+}
+case class PersistentRoutineOperationMeta(
+    remote: BQPersistentRoutine.Unknown,
+    local: BQPersistentRoutine.Unknown
+) extends OperationMeta {
+  override def identifier: String = local.name.asString
+}
+
+case class ExistingTable(our: BQTableDef[Any], table: TableInfo)
+case class ExistingRoutine(our: BQPersistentRoutine.Unknown, routine: RoutineInfo)
+
+sealed trait UpdateOperation
+object UpdateOperation {
+  case class Noop(meta: OperationMeta) extends UpdateOperation
+
+  sealed trait Success extends UpdateOperation
+
+  /** @param patched
+    *   It's not allowed to provide schema when creating a view
+    */
+  case class CreateTable(local: BQTableDef[Any], patched: Option[BQTableDef[Any]]) extends Success
+
+  case class UpdateTable(existing: ExistingTable, local: BQTableDef.Table[Any]) extends Success
+
+  case class RecreateView(
+      existingRemoteTable: ExistingTable,
+      localTableDef: BQTableDef.ViewLike[Any],
+      create: CreateTable)
+      extends Success
+
+  case class CreateTvf(tvf: TVF[Any, ?]) extends Success
+
+  case class UpdateTvf(existing: ExistingRoutine, tvf: TVF[Any, ?]) extends Success
+
+  case class CreatePersistentUdf(udf: UDF.Persistent[?]) extends Success
+  case class UpdatePersistentUdf(existing: ExistingRoutine, udf: UDF.Persistent[?]) extends Success
+
+  sealed trait Error extends UpdateOperation
+
+  case class Illegal(meta: OperationMeta, reason: String) extends Error
+  case class UnsupportedPartitioning(meta: OperationMeta, msg: String) extends Error
+  case class IllegalSchemaExtension(meta: OperationMeta, reason: String) extends Error
+
+}

--- a/core/src/main/scala/no/nrk/bigquery/internal/RoutineHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/RoutineHelper.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.internal
+
+import com.google.cloud.bigquery.{Option as _, *}
+import no.nrk.bigquery.UDF.Body
+import no.nrk.bigquery.*
+import no.nrk.bigquery.util.ToSized
+
+import scala.jdk.CollectionConverters.*
+
+object RoutineHelper {
+
+  private[bigquery] val UdfRoutineType = "SCALAR_FUNCTION"
+  private[bigquery] val TvfRoutineType = "TABLE_VALUED_FUNCTION"
+
+  def fromGoogle(r: RoutineInfo): BQPersistentRoutine.Unknown = r.getRoutineType match {
+    case TvfRoutineType =>
+      tvfFromRoutine(r)
+    case UdfRoutineType =>
+      udfFromRoutine(r)
+    case x => throw new UnsupportedOperationException(s"conversion of Routine of type $x is not supported")
+  }
+
+  def tvfFromRoutine(routine: RoutineInfo): TVF[Unit, ?] =
+    TVF(
+      TVF.TVFId(
+        BQDataset.Ref(ProjectId.unsafeFromString(routine.getRoutineId.getProject), routine.getRoutineId.getDataset),
+        Ident(routine.getRoutineId.getRoutine)
+      ),
+      BQPartitionType.NotPartitioned,
+      toParams(routine),
+      BQSqlFrag.Frag(routine.getBody),
+      fromReturnTableType(routine.getReturnTableType),
+      Option(routine.getDescription)
+    )
+
+  private def toParams(routine: RoutineInfo) =
+    Option(routine.getArguments)
+      .map(_.asScala.map(ra =>
+        BQRoutine.Param(Ident(ra.getName), Option(ra.getDataType).flatMap(SchemaHelper.typeFrom))))
+      .map(buf => ToSized(buf.toList))
+      .getOrElse(BQRoutine.Params.empty.asInstanceOf[util.Sized[IndexedSeq[BQRoutine.Param], util.NatUnknown]])
+
+  def udfFromRoutine(routine: RoutineInfo): UDF.Persistent[?] =
+    UDF.Persistent(
+      UDF.UDFId.PersistentId(
+        BQDataset.Ref(ProjectId.unsafeFromString(routine.getRoutineId.getProject), routine.getRoutineId.getDataset),
+        Ident(routine.getRoutineId.getRoutine)
+      ),
+      toParams(routine),
+      routine.getLanguage match {
+        case "JAVASCRIPT" =>
+          UDF.Body.Js(routine.getBody, Option(routine.getImportedLibraries).map(_.asScala.toList).getOrElse(Nil))
+        case "SQL" => UDF.Body.Sql(Option(routine.getBody).map(BQSqlFrag.Frag.apply).getOrElse(BQSqlFrag.Empty))
+        case x => sys.error(s"Unknown language '$x' for function ${routine.getRoutineId}")
+      },
+      returnType = Option(routine.getReturnType).flatMap(SchemaHelper.typeFrom)
+      // Option(routine.getDescription)
+    )
+
+  def fromReturnTableType(ttt: StandardSQLTableType): BQSchema = {
+
+    def fromStandardField(dt: StandardSQLField): Option[BQField] = for {
+      typ <- SchemaHelper.typeFrom(dt.getDataType)
+    } yield BQField(dt.getName, typ.tpe, typ.mode, None, typ.asSchema.toOption.map(_.fields).getOrElse(Nil))
+
+    BQSchema(ttt.getColumns.iterator().asScala.flatMap(f => fromStandardField(f)).toList)
+  }
+
+  def toGoogle(
+      routine: BQPersistentRoutine.Unknown,
+      maybeExisting: Option[RoutineInfo]
+  ): RoutineInfo =
+    routine match {
+      case tvf: TVF[Any, ?] => createTvfRoutineInfo(tvf, maybeExisting)
+      case udf: UDF.Persistent[?] => createUdfRoutineInfo(udf, maybeExisting)
+    }
+
+  private def createTvfRoutineInfo(tvf: TVF[Any, ?], maybeExisting: Option[RoutineInfo]) =
+    maybeExisting
+      .map(_.toBuilder)
+      .getOrElse(RoutineInfo
+        .newBuilder(toRoutineId(tvf.name)))
+      .setRoutineType(TvfRoutineType)
+      .setArguments(tvf.params.unsized.toList.map(toRoutineArgs).asJava)
+      .setLanguage("SQL")
+      .setBody(tvf.query.asString)
+      // function not public in Builder: .setDescription(tvf.description.orNull)
+      .setReturnTableType(
+        StandardSQLTableType
+          .newBuilder()
+          .setColumns(
+            tvf.schema.fields
+              .map(field => StandardSQLField.newBuilder(field.name, toSqlDataType(BQType.fromField(field))).build())
+              .asJava)
+          .build()
+      )
+      .setImportedLibraries(List.empty.asJava)
+      .build()
+
+  private def createUdfRoutineInfo(udf: UDF.Persistent[?], maybeExisting: Option[RoutineInfo]) = {
+    val baseBuilder = maybeExisting
+      .map(_.toBuilder)
+      .getOrElse(RoutineInfo
+        .newBuilder(toRoutineId(udf.name)))
+      .setRoutineType(UdfRoutineType)
+      .setArguments(udf.params.unsized.map(toRoutineArgs).asJava)
+      .setReturnType(udf.returnType.map(toSqlDataType).orNull)
+
+    (udf.body match {
+      case s: Body.Sql =>
+        baseBuilder
+          .setLanguage("SQL")
+          .setBody(s.asFragment.asString)
+          .setImportedLibraries(List.empty.asJava)
+      case Body.Js(javascriptSnippet, gsLibraryPath) =>
+        baseBuilder
+          .setLanguage("JAVASCRIPT")
+          .setBody(javascriptSnippet)
+          .setImportedLibraries(gsLibraryPath.asJava)
+    }).build()
+  }
+
+  private def toRoutineId(id: BQPersistentRoutine.Id) =
+    RoutineId.of(id.dataset.project.value, id.dataset.id, id.name.value)
+
+  private def toRoutineArgs(param: BQRoutine.Param): RoutineArgument =
+    param.maybeType match {
+      case Some(value) =>
+        RoutineArgument
+          .newBuilder()
+          .setName(param.name.value)
+          .setDataType(toSqlDataType(value))
+          .build()
+      case None =>
+        RoutineArgument
+          .newBuilder()
+          .setName(param.name.value)
+          .setKind("ANY_TYPE")
+          .build()
+    }
+
+  private def toSqlDataType(bqType: BQType): StandardSQLDataType = {
+    val dataType =
+      if (bqType.tpe == BQField.Type.STRUCT)
+        StandardSQLDataType
+          .newBuilder()
+          .setTypeKind(BQField.Type.STRUCT.name)
+          .setStructType(
+            StandardSQLStructType
+              .newBuilder()
+              .setFields(bqType.subFields.map { case (name, fieldBqType) =>
+                StandardSQLField.newBuilder(name, toSqlDataType(fieldBqType)).build()
+              }.asJava)
+              .build())
+          .build()
+      else StandardSQLDataType.newBuilder().setTypeKind(bqType.tpe.name).build()
+
+    if (bqType.mode == BQField.Mode.REPEATED)
+      StandardSQLDataType
+        .newBuilder()
+        .setTypeKind(BQField.Type.ARRAY.name)
+        .setArrayElementType(dataType)
+        .build()
+    else dataType
+  }
+}

--- a/core/src/main/scala/no/nrk/bigquery/internal/RoutineUpdateOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/RoutineUpdateOperation.scala
@@ -4,159 +4,68 @@
  * SPDX-License-Identifier: MIT
  */
 
-package no.nrk.bigquery.internal
+package no.nrk.bigquery
+package internal
 
-import com.google.cloud.bigquery.{Option as _, *}
-import no.nrk.bigquery.UDF.Body
-import no.nrk.bigquery.{
-  BQField,
-  BQPersistentRoutine,
-  BQRoutine,
-  BQType,
-  PersistentRoutineOperationMeta,
-  TVF,
-  UDF,
-  UpdateOperation
-}
-
-import scala.jdk.CollectionConverters.*
+import cats.Eq
 
 object RoutineUpdateOperation {
+  implicit val eqUDF: Eq[UDF.Persistent[?]] = Eq.instance { (a, b) =>
+    a.name == b.name &&
+    a.params == b.params &&
+    a.body.asFragment.asString == b.body.asFragment.asString &&
+    a.returnType == b.returnType
+  }
 
-  private val UdfRoutineType = "SCALAR_FUNCTION"
-  private val TvfRoutineType = "TABLE_VALUED_FUNCTION"
+  implicit val eqTVF: Eq[TVF[?, ?]] = Eq.instance { (a, b) =>
+    a.name == b.name &&
+    a.params == b.params &&
+    a.description == b.description &&
+    conforms.onlyTypes(a.schema, b.schema).exists(_.isEmpty) &&
+    a.partitionType == b.partitionType
+    a.query.asString == a.query.asString
+  }
 
   def from(
-      routine: BQPersistentRoutine[?, ?],
-      maybeExisting: Option[RoutineInfo]
-  ): UpdateOperation = maybeExisting match {
-    case None =>
-      routine match {
-        case tvf: TVF[Any, ?] =>
-          UpdateOperation.CreateTvf(tvf, createTvfRoutineInfo(tvf))
-        case udf: UDF.Persistent[?] =>
-          UpdateOperation.CreatePersistentUdf(udf, createUdfRoutineInfo(udf))
-      }
-    case Some(value) =>
-      val tpe = routine match {
-        case _: TVF[Any, ?] => TvfRoutineType
-        case _: UDF.Persistent[?] => UdfRoutineType
-      }
-      if (value.getRoutineType != tpe)
-        UpdateOperation.Illegal(
-          PersistentRoutineOperationMeta(value, routine),
-          s"Routine type ${value.getRoutineType} did not match expected routine $tpe")
-      else {
-        val recreated = recreateRoutine(value)
-        val routineInfo = routine match {
-          case tvf: TVF[Any, ?] => createTvfRoutineInfo(tvf)
-          case udf: UDF.Persistent[?] => createUdfRoutineInfo(udf)
-        }
-        if (recreated == routineInfo)
-          UpdateOperation.Noop(PersistentRoutineOperationMeta(value, routine))
-        else {
-          routine match {
-            case tvf: TVF[Any, ?] => UpdateOperation.UpdateTvf(tvf, routineInfo)
-            case udf: UDF.Persistent[?] => UpdateOperation.UpdatePersistentUdf(udf, routineInfo)
-          }
-        }
-      }
-  }
-
-  private def createTvfRoutineInfo(tvf: TVF[Any, ?]) =
-    RoutineInfo
-      .newBuilder(toRoutineId(tvf.name))
-      .setRoutineType(TvfRoutineType)
-      .setArguments(tvf.params.unsized.toList.map(toRoutineArgs).asJava)
-      .setLanguage("SQL")
-      .setBody(tvf.query.asString)
-      // function not public in Builder: .setDescription(tvf.description.orNull)
-      .setReturnTableType(
-        StandardSQLTableType
-          .newBuilder()
-          .setColumns(
-            tvf.schema.fields
-              .map(field => StandardSQLField.newBuilder(field.name, toSqlDataType(BQType.fromField(field))).build())
-              .asJava)
-          .build()
-      )
-      .setImportedLibraries(List.empty.asJava)
-      .build()
-
-  private def createUdfRoutineInfo(udf: UDF.Persistent[?]) = {
-    val baseBuilder = RoutineInfo
-      .newBuilder(toRoutineId(udf.name))
-      .setRoutineType(UdfRoutineType)
-      .setArguments(udf.params.unsized.map(toRoutineArgs).asJava)
-      .setReturnType(udf.returnType.map(toSqlDataType).orNull)
-
-    (udf.body match {
-      case s: Body.Sql =>
-        baseBuilder
-          .setLanguage("SQL")
-          .setBody(s.asFragment.asString)
-          .setImportedLibraries(List.empty.asJava)
-      case Body.Js(javascriptSnippet, gsLibraryPath) =>
-        baseBuilder
-          .setLanguage("JAVASCRIPT")
-          .setBody(javascriptSnippet)
-          .setImportedLibraries(gsLibraryPath.asJava)
-    }).build()
-  }
-
-  private def recreateRoutine(r: RoutineInfo) =
-    RoutineInfo
-      .newBuilder(r.getRoutineId)
-      .setRoutineType(r.getRoutineType)
-      .setArguments(Option(r.getArguments).getOrElse(List.empty.asJava))
-      .setReturnType(r.getReturnType)
-      .setReturnTableType(r.getReturnTableType)
-      .setLanguage(r.getLanguage)
-      .setBody(r.getBody)
-      .setImportedLibraries(Option(r.getImportedLibraries).getOrElse(List.empty.asJava))
-      .build()
-
-  private def toRoutineId(id: BQPersistentRoutine.Id) =
-    RoutineId.of(id.dataset.project.value, id.dataset.id, id.name.value)
-
-  private def toRoutineArgs(param: BQRoutine.Param): RoutineArgument =
-    param.maybeType match {
-      case Some(value) =>
-        RoutineArgument
-          .newBuilder()
-          .setName(param.name.value)
-          .setDataType(toSqlDataType(value))
-          .build()
+      routine: BQPersistentRoutine.Unknown,
+      maybeExisting: Option[ExistingRoutine]
+  ): UpdateOperation =
+    maybeExisting match {
       case None =>
-        RoutineArgument
-          .newBuilder()
-          .setName(param.name.value)
-          .setKind("ANY_TYPE")
-          .build()
+        routine match {
+          case tvf: TVF[Any, ?] =>
+            UpdateOperation.CreateTvf(tvf)
+          case udf: UDF.Persistent[?] =>
+            UpdateOperation.CreatePersistentUdf(udf)
+        }
+      case Some(remoteValue) =>
+        (routine, remoteValue.our) match {
+          case (local: TVF[?, ?], remote: TVF[?, ?]) =>
+            val patched = remote.withParitionType(local.partitionType)
+            if (eqTVF.eqv(local, patched)) {
+              UpdateOperation.Noop(PersistentRoutineOperationMeta(remote, routine))
+            } else {
+              conforms.onlyTypes(local.schema, remote.schema) match {
+                case Some(illegalFields) =>
+                  UpdateOperation.IllegalSchemaExtension(
+                    PersistentRoutineOperationMeta(remote, routine),
+                    illegalFields.mkString(", "))
+                case None =>
+                  UpdateOperation.UpdateTvf(remoteValue, local)
+
+              }
+            }
+          case (local: UDF.Persistent[?], remote: UDF.Persistent[?]) =>
+            if (eqUDF.eqv(local, remote)) {
+              UpdateOperation.Noop(PersistentRoutineOperationMeta(remote, routine))
+            } else {
+              UpdateOperation.UpdatePersistentUdf(remoteValue, local)
+            }
+          case (local, remote) =>
+            UpdateOperation.Illegal(
+              PersistentRoutineOperationMeta(local, remote),
+              s"Cannot convert from '${remote.getClass.getSimpleName}' to '${local.getClass.getSimpleName}'"
+            )
+        }
     }
-
-  private def toSqlDataType(bqType: BQType): StandardSQLDataType = {
-    val dataType =
-      if (bqType.tpe == BQField.Type.STRUCT)
-        StandardSQLDataType
-          .newBuilder()
-          .setTypeKind(BQField.Type.STRUCT.name)
-          .setStructType(
-            StandardSQLStructType
-              .newBuilder()
-              .setFields(bqType.subFields.map { case (name, fieldBqType) =>
-                StandardSQLField.newBuilder(name, toSqlDataType(fieldBqType)).build()
-              }.asJava)
-              .build())
-          .build()
-      else StandardSQLDataType.newBuilder().setTypeKind(bqType.tpe.name).build()
-
-    if (bqType.mode == BQField.Mode.REPEATED)
-      StandardSQLDataType
-        .newBuilder()
-        .setTypeKind(BQField.Type.ARRAY.name)
-        .setArrayElementType(dataType)
-        .build()
-    else dataType
-  }
 }

--- a/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
@@ -18,16 +18,17 @@ object SchemaHelper {
   def toSchema(schema: BQSchema): Schema =
     Schema.of(schema.fields.map(toField)*)
 
-  def typeFrom(dt: StandardSQLDataType): Option[BQType] = for {
-    typ <- BQField.Type.fromString(dt.getTypeKind)
-    arr = Option(dt.getArrayElementType).flatMap(e => typeFrom(e))
-    struct = Option(dt.getStructType).map(e =>
-      e.getFields.asScala.flatMap(f => typeFrom(f.getDataType).map(t => f.getName -> t)).toList)
-  } yield BQType(
-    if (arr.isDefined) BQField.Mode.REPEATED else BQField.Mode.NULLABLE,
-    arr.map(_.tpe).getOrElse(typ),
-    struct.orElse(arr.map(_.subFields)).getOrElse(Nil)
-  )
+  def typeFrom(dt: StandardSQLDataType): Option[BQType] =
+    for {
+      typ <- BQField.Type.fromString(dt.getTypeKind)
+      arr = Option(dt.getArrayElementType).flatMap(e => typeFrom(e))
+      struct = Option(dt.getStructType).map(e =>
+        e.getFields.asScala.flatMap(f => typeFrom(f.getDataType).map(t => f.getName -> t)).toList)
+    } yield BQType(
+      if (arr.isDefined) BQField.Mode.REPEATED else BQField.Mode.NULLABLE,
+      arr.map(_.tpe).getOrElse(typ),
+      struct.orElse(arr.map(_.subFields)).getOrElse(Nil)
+    )
 
   def fromSchema(schema: Schema): BQSchema =
     schema match {

--- a/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/SchemaHelper.scala
@@ -18,74 +18,16 @@ object SchemaHelper {
   def toSchema(schema: BQSchema): Schema =
     Schema.of(schema.fields.map(toField)*)
 
-  sealed trait TableConversionError
-  object TableConversionError {
-    final case class IllegalTableId(msg: String) extends TableConversionError
-    final case class UnsupportedPartitionType(msg: String) extends TableConversionError
-    final case class UnsupportedTableType(msg: String) extends TableConversionError
-  }
-
-  def fromTable(table: TableInfo): Either[TableConversionError, BQTableDef[Any]] = {
-    val id = List(
-      Option(table.getTableId.getProject),
-      Option(table.getTableId.getDataset),
-      Option(table.getTableId.getTable)).flatten.mkString(".")
-    val parsedId = BQTableId.fromString(id).left.map(msg => TableConversionError.IllegalTableId(msg))
-
-    table.getDefinition[TableDefinition] match {
-      case st: StandardTableDefinition =>
-        for {
-          typ <- PartitionTypeHelper.from(st).left.map(msg => TableConversionError.UnsupportedPartitionType(msg))
-          tableId <- parsedId
-        } yield BQTableDef.Table(
-          tableId = tableId,
-          schema = fromSchema(st.getSchema),
-          partitionType = typ,
-          description = Option(table.getDescription),
-          clustering = Option(st.getClustering).toList
-            .flatMap(_.getFields.asScala)
-            .map(Ident.apply),
-          labels = GoogleTypeHelper.tableLabelsfromTableInfo(table),
-          tableOptions = GoogleTypeHelper.toTableOptions(table)
-        )
-
-      case v: ViewDefinition =>
-        parsedId.map(tableId =>
-          BQTableDef.View(
-            tableId = tableId,
-            schema = fromSchema(v.getSchema),
-            partitionType = BQPartitionType.NotPartitioned,
-            description = Option(table.getDescription),
-            labels = GoogleTypeHelper.tableLabelsfromTableInfo(table),
-            query = BQSqlFrag.Frag(v.getQuery)
-          ))
-
-      case v: MaterializedViewDefinition =>
-        for {
-          typ <- PartitionTypeHelper.from(v).left.map(msg => TableConversionError.UnsupportedPartitionType(msg))
-          tableId <- parsedId
-
-        } yield BQTableDef.MaterializedView(
-          tableId = tableId,
-          schema = fromSchema(v.getSchema),
-          partitionType = typ,
-          description = Option(table.getDescription),
-          enableRefresh = Option(v.getEnableRefresh).forall(_.booleanValue()),
-          refreshIntervalMs = Option(v.getRefreshIntervalMs).map(_.longValue()).getOrElse(1800000L),
-          /*
-          TODO: Add clustering to BQTableDef.MaterializedView
-
-          clustering = Option(st.getClustering).toList
-                .flatMap(_.getFields.asScala)
-                .map(Ident.apply),*/
-          labels = GoogleTypeHelper.tableLabelsfromTableInfo(table),
-          query = BQSqlFrag.Frag(v.getQuery),
-          tableOptions = GoogleTypeHelper.toTableOptions(table)
-        )
-
-      case s => Left(TableConversionError.UnsupportedTableType(s"${s.getType.name()} is not supported here"))
-    }
-  }
+  def typeFrom(dt: StandardSQLDataType): Option[BQType] = for {
+    typ <- BQField.Type.fromString(dt.getTypeKind)
+    arr = Option(dt.getArrayElementType).flatMap(e => typeFrom(e))
+    struct = Option(dt.getStructType).map(e =>
+      e.getFields.asScala.flatMap(f => typeFrom(f.getDataType).map(t => f.getName -> t)).toList)
+  } yield BQType(
+    if (arr.isDefined) BQField.Mode.REPEATED else BQField.Mode.NULLABLE,
+    arr.map(_.tpe).getOrElse(typ),
+    struct.orElse(arr.map(_.subFields)).getOrElse(Nil)
+  )
 
   def fromSchema(schema: Schema): BQSchema =
     schema match {

--- a/core/src/main/scala/no/nrk/bigquery/internal/TableHelper.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/TableHelper.scala
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2020 NRK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package no.nrk.bigquery.internal
+
+import com.google.cloud.bigquery.{Option as _, *}
+import no.nrk.bigquery.*
+
+import scala.jdk.CollectionConverters.*
+import GoogleTypeHelper.*
+import no.nrk.bigquery.internal.SchemaHelper.fromSchema
+
+object TableHelper {
+  sealed trait TableConversionError
+  object TableConversionError {
+    final case class IllegalTableId(msg: String) extends TableConversionError
+    final case class UnsupportedPartitionType(msg: String) extends TableConversionError
+    final case class UnsupportedTableType(msg: String) extends TableConversionError
+  }
+
+  def fromTable(table: TableInfo): Either[TableConversionError, BQTableDef[Any]] = {
+    val id = List(
+      Option(table.getTableId.getProject),
+      Option(table.getTableId.getDataset),
+      Option(table.getTableId.getTable)).flatten.mkString(".")
+    val parsedId = BQTableId.fromString(id).left.map(msg => TableConversionError.IllegalTableId(msg))
+
+    table.getDefinition[TableDefinition] match {
+      case st: StandardTableDefinition =>
+        for {
+          typ <- PartitionTypeHelper.from(st).left.map(msg => TableConversionError.UnsupportedPartitionType(msg))
+          tableId <- parsedId
+        } yield BQTableDef.Table(
+          tableId = tableId,
+          schema = fromSchema(st.getSchema),
+          partitionType = typ,
+          description = Option(table.getDescription),
+          clustering = Option(st.getClustering).toList
+            .flatMap(_.getFields.asScala)
+            .map(Ident.apply),
+          labels = GoogleTypeHelper.tableLabelsfromTableInfo(table),
+          tableOptions = GoogleTypeHelper.toTableOptions(table)
+        )
+
+      case v: ViewDefinition =>
+        parsedId.map(tableId =>
+          BQTableDef.View(
+            tableId = tableId,
+            schema = fromSchema(v.getSchema),
+            partitionType = BQPartitionType.NotPartitioned,
+            description = Option(table.getDescription),
+            labels = GoogleTypeHelper.tableLabelsfromTableInfo(table),
+            query = BQSqlFrag.Frag(v.getQuery)
+          ))
+
+      case v: MaterializedViewDefinition =>
+        for {
+          typ <- PartitionTypeHelper.from(v).left.map(msg => TableConversionError.UnsupportedPartitionType(msg))
+          tableId <- parsedId
+
+        } yield BQTableDef.MaterializedView(
+          tableId = tableId,
+          schema = fromSchema(v.getSchema),
+          partitionType = typ,
+          description = Option(table.getDescription),
+          enableRefresh = Option(v.getEnableRefresh).forall(_.booleanValue()),
+          refreshIntervalMs = Option(v.getRefreshIntervalMs).map(_.longValue()).getOrElse(1800000L),
+          /*
+          TODO: Add clustering to BQTableDef.MaterializedView
+
+          clustering = Option(st.getClustering).toList
+                .flatMap(_.getFields.asScala)
+                .map(Ident.apply),*/
+          labels = GoogleTypeHelper.tableLabelsfromTableInfo(table),
+          query = BQSqlFrag.Frag(v.getQuery),
+          tableOptions = GoogleTypeHelper.toTableOptions(table)
+        )
+
+      case s => Left(TableConversionError.UnsupportedTableType(s"${s.getType.name()} is not supported here"))
+    }
+  }
+
+  def from(
+      tableDef: BQTableDef[Any],
+      maybeExisting: Option[TableInfo]
+  ): TableInfo =
+    maybeExisting match {
+      case None =>
+        createNew(tableDef)
+
+      case Some(existingRemoteTable) =>
+        tableDef match {
+          case local: BQTableDef.Table[Any] =>
+            updateTable(existingRemoteTable, local)
+
+          case local: BQTableDef.ViewLike[Any] =>
+            val recreate = createNew(local)
+            val updatedLabels =
+              labelsForUpdate(local.labels, Some(GoogleTypeHelper.tableLabelsfromTableInfo(existingRemoteTable)))
+            recreate.toBuilder.setLabels(updatedLabels).build()
+        }
+    }
+
+  private def updateTable(existingRemoteTable: TableInfo, local: BQTableDef.Table[Any]) = {
+    val existingLabels = GoogleTypeHelper.tableLabelsfromTableInfo(existingRemoteTable)
+    // unpack values from `localTableDef`. This will break compilation we add more fields, reminding us to update here
+    val BQTableDef.Table(
+      _,
+      schema,
+      partitioning,
+      description,
+      clustering,
+      labels,
+      tableOptions
+    ) = local
+
+    existingRemoteTable.toBuilder
+      .setDefinition {
+        StandardTableDefinition.newBuilder
+          .setSchema(SchemaHelper.toSchema(schema))
+          .setTimePartitioning(
+            PartitionTypeHelper.timePartitioned(partitioning, tableOptions).orNull
+          )
+          .setRangePartitioning(
+            PartitionTypeHelper.rangepartitioned(partitioning).orNull
+          )
+          .setClustering(clusteringFrom(clustering).orNull)
+          .build()
+      }
+      .setRequirePartitionFilter(
+        // Override partitionFilterRequired flag if the table is not partitioned.
+        partitioning match {
+          case BQPartitionType.DatePartitioned(_) => tableOptions.partitionFilterRequired
+          case BQPartitionType.MonthPartitioned(_) => tableOptions.partitionFilterRequired
+          case _ => null
+        }
+      )
+      .setDescription(description.orNull)
+      .setLabels(labelsForUpdate(labels, Some(existingLabels)))
+      .build()
+  }
+
+  def createNew(localTableDef: BQTableDef[Any]): TableInfo =
+    localTableDef match {
+      // Views must first be created without schema, then updated with schema. (2021-01-13)
+      case BQTableDef.View(tableId, _, query, schema, description, labels) =>
+        val withoutSchema: TableInfo =
+          newTable(
+            tableId.underlying,
+            ViewDefinition.of(query.asStringWithUDFs),
+            TableOptions.Empty,
+            description,
+            labels
+          )
+
+        val withSchema: TableInfo =
+          withoutSchema.toBuilder
+            .setDefinition(
+              withoutSchema
+                .getDefinition[ViewDefinition]
+                .toBuilder
+                .setSchema(SchemaHelper.toSchema(schema))
+                .build()
+            )
+            .build()
+
+        if (schema.fields.isEmpty) withoutSchema else withSchema
+
+      case BQTableDef.Table(
+            tableId,
+            schema,
+            partitionType,
+            description,
+            clustering,
+            labels,
+            tableOptions
+          ) =>
+        val toCreate: TableInfo =
+          newTable(
+            tableId.underlying,
+            StandardTableDefinition.newBuilder
+              .setSchema(SchemaHelper.toSchema(schema))
+              .setTimePartitioning(PartitionTypeHelper.timePartitioned(partitionType, tableOptions).orNull)
+              .setRangePartitioning(PartitionTypeHelper.rangepartitioned(partitionType).orNull)
+              .setClustering(clusteringFrom(clustering).orNull)
+              .build,
+            tableOptions,
+            description,
+            labels
+          )
+        toCreate
+
+      case BQTableDef.MaterializedView(
+            tableId,
+            partitionType,
+            query,
+            schema @ _,
+            enableRefresh,
+            refreshIntervalMs,
+            description,
+            labels,
+            tableOptions
+          ) =>
+        val toCreate: TableInfo =
+          newTable(
+            tableId.underlying,
+            MaterializedViewDefinition
+              .newBuilder(query.asStringWithUDFs)
+              .setEnableRefresh(enableRefresh)
+              // .setSchema(schema.toSchema)  // not possible for now
+              .setRefreshIntervalMs(refreshIntervalMs)
+              .setTimePartitioning(PartitionTypeHelper.timePartitioned(partitionType, tableOptions).orNull)
+              .setRangePartitioning(PartitionTypeHelper.rangepartitioned(partitionType).orNull)
+              .build(),
+            tableOptions,
+            description,
+            labels
+          )
+
+        toCreate
+    }
+
+  /** This method is needed for the case where we delete a label. It is deleted by setting it to `null`.
+    *
+    * As such, we need to know the labels of a table in production before we compute the new set of labels to use when
+    * updating
+    */
+  def labelsForUpdate(labels: TableLabels, existingLabels: Option[TableLabels]): java.util.Map[String, String] = {
+    val ret = new java.util.TreeMap[String, String]
+
+    // existing table? set all old label keys to `null`
+    for {
+      exLabels <- existingLabels.toList
+      existingKey <- exLabels.values.keySet
+    } ret.put(existingKey, null)
+
+    // and overwrite the ones we want to keep.
+    labels.values.foreach { case (key, value) => ret.put(key, value) }
+
+    ret
+  }
+
+  private def newTable(
+      tableId: TableId,
+      definition: TableDefinition,
+      tableOptions: TableOptions,
+      description: Option[String],
+      labels: TableLabels
+  ): TableInfo = {
+    val builder = TableInfo
+      .newBuilder(tableId, definition)
+      .setDescription(description.orNull)
+      .setLabels(labelsForUpdate(labels, existingLabels = None))
+
+    // For some reason requirePartitionFilter = false <> requirePartitionFilter = null
+    if (tableOptions.partitionFilterRequired) {
+      builder.setRequirePartitionFilter(tableOptions.partitionFilterRequired).build()
+    } else {
+      builder.build()
+    }
+  }
+
+  private def clusteringFrom(clustering: List[Ident]): Option[Clustering] =
+    clustering match {
+      case Nil => None
+      case nonEmpty =>
+        Some(
+          Clustering
+            .newBuilder()
+            .setFields(nonEmpty.map(_.value).asJava)
+            .build()
+        )
+    }
+}

--- a/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/TableUpdateOperation.scala
@@ -4,17 +4,14 @@
  * SPDX-License-Identifier: MIT
  */
 
-package no.nrk.bigquery.internal
+package no.nrk.bigquery
+package internal
 
-import com.google.cloud.bigquery.{Option as _, *}
-import no.nrk.bigquery.*
-
-import scala.jdk.CollectionConverters.*
-import GoogleTypeHelper.*
 import cats.Eq
 import cats.syntax.all.*
 
 object TableUpdateOperation {
+  private implicit val partitionTypeEquality: Eq[BQPartitionType[Any]] = Eq.instance((a, b) => a == b)
 
   private implicit val tableDefEquality: Eq[BQTableDef.Table[Any]] = Eq.instance { (a, b) =>
     a.tableId == b.tableId &&
@@ -29,8 +26,8 @@ object TableUpdateOperation {
   private implicit val viewDefEquality: Eq[BQTableDef.View[Any]] = Eq.instance { (a, b) =>
     a.tableId == b.tableId &&
     a.schema == b.schema &&
-    a.partitionType == b.partitionType &&
-    a.query == b.query &&
+    a.partitionType === b.partitionType &&
+    a.query.asString == b.query.asString &&
     a.description == b.description &&
     a.labels == b.labels
   }
@@ -38,8 +35,8 @@ object TableUpdateOperation {
   private implicit val materializedViewDefEquality: Eq[BQTableDef.MaterializedView[Any]] = Eq.instance { (a, b) =>
     a.tableId == b.tableId &&
     a.schema == b.schema &&
-    a.partitionType == b.partitionType &&
-    a.query == b.query &&
+    a.partitionType === b.partitionType &&
+    a.query.asString == b.query.asString &&
     a.description == b.description &&
     a.labels == b.labels &&
     a.enableRefresh == b.enableRefresh &&
@@ -49,255 +46,94 @@ object TableUpdateOperation {
 
   def from(
       tableDef: BQTableDef[Any],
-      maybeExisting: Option[TableInfo]
+      maybeExisting: Option[ExistingTable]
   ): UpdateOperation =
     maybeExisting match {
       case None =>
-        createNew(tableDef)
+        tableDef match {
+          case t: BQTableDef.Table[?] =>
+            UpdateOperation.CreateTable(t, None)
+          case view: BQTableDef.View[?] =>
+            UpdateOperation.CreateTable(view.copy(schema = BQSchema.of()), Some(view))
+          case matView: BQTableDef.MaterializedView[?] =>
+            UpdateOperation.CreateTable(matView, None)
+        }
 
-      case Some(existingRemoteTable) =>
-        SchemaHelper.fromTable(existingRemoteTable) match {
-          case Left(SchemaHelper.TableConversionError.UnsupportedPartitionType(msg)) =>
-            UpdateOperation.UnsupportedPartitioning(TableDefOperationMeta(existingRemoteTable, tableDef), msg)
-          case Left(SchemaHelper.TableConversionError.UnsupportedTableType(msg)) =>
-            UpdateOperation.Illegal(TableDefOperationMeta(existingRemoteTable, tableDef), msg)
-          case Left(SchemaHelper.TableConversionError.IllegalTableId(msg)) =>
-            UpdateOperation.Illegal(TableDefOperationMeta(existingRemoteTable, tableDef), msg)
-          case Right(remoteDef) =>
-            (tableDef -> remoteDef) match {
-              case (local: BQTableDef.Table[Any], remote: BQTableDef.Table[Any])
-                  if remote.partitionType == local.partitionType =>
-                val illegalSchemaExtension: Option[UpdateOperation.IllegalSchemaExtension] =
-                  conforms
-                    .onlyTypes(
-                      actualSchema = remote.schema,
-                      givenSchema = local.schema
-                    )
-                    .map { reasons =>
-                      UpdateOperation.IllegalSchemaExtension(
-                        TableDefOperationMeta(existingRemoteTable, tableDef),
-                        reasons.mkString(", ")
-                      )
-                    }
-
-                if (local === remote)
-                  UpdateOperation.Noop(TableDefOperationMeta(existingRemoteTable, local))
-                else
-                  illegalSchemaExtension.getOrElse {
-                    val updatedTable: TableInfo = updateTable(existingRemoteTable, local, remote)
-                    UpdateOperation.UpdateTable(
-                      existingRemoteTable,
-                      local,
-                      updatedTable
-                    )
-                  }
-              case (local: BQTableDef.Table[Any], remote: BQTableDef.Table[Any]) =>
-                UpdateOperation.UnsupportedPartitioning(
-                  TableDefOperationMeta(existingRemoteTable, local),
-                  s"Cannot change partitioning from ${remote.partitionType} to ${local.partitionType}"
+      case Some(existingDef) =>
+        (tableDef -> existingDef.our) match {
+          case (local: BQTableDef.Table[Any], remote: BQTableDef.Table[Any])
+              if remote.partitionType === local.partitionType =>
+            val illegal = conforms
+              .onlyTypes(
+                actualSchema = remote.schema,
+                givenSchema = local.schema
+              )
+              .map { reasons =>
+                UpdateOperation.IllegalSchemaExtension(
+                  TableDefOperationMeta(remote, local),
+                  reasons.mkString(", ")
                 )
-              case (local: BQTableDef.View[Any], remote: BQTableDef.View[Any]) =>
-                if (local === remote.withTableType(local.partitionType))
-                  UpdateOperation.Noop(TableDefOperationMeta(existingRemoteTable, local))
-                else
-                  UpdateOperation.RecreateView(
-                    existingRemoteTable,
-                    local,
-                    createNew(local)
-                  )
+              }
 
-              case (local: BQTableDef.MaterializedView[Any], remote: BQTableDef.MaterializedView[Any])
-                  if local.partitionType == remote.partitionType =>
-                def outline(field: BQField): BQField =
-                  field.copy(
-                    mode = BQField.Mode.NULLABLE,
-                    description = None,
-                    subFields = field.subFields.map(outline)
-                  )
+            if (local === remote)
+              UpdateOperation.Noop(TableDefOperationMeta(remote, local))
+            else
+              illegal.getOrElse {
+                UpdateOperation.UpdateTable(existingDef, local)
+              }
 
-                val patchedLocalMVDef =
-                  local.copy(
-                    // Materialized views are given a schema, but we cant affect it in any way.
-                    schema = BQSchema(local.schema.fields.map(outline)),
-                    // Override partitionFilterRequired flag if the view is not partitioned.
-                    tableOptions = local.partitionType match {
-                      case BQPartitionType.DatePartitioned(_) => local.tableOptions
-                      case BQPartitionType.MonthPartitioned(_) => local.tableOptions
-                      case _ => local.tableOptions.copy(partitionFilterRequired = false)
-                    }
-                  )
-
-                if (patchedLocalMVDef === remote)
-                  UpdateOperation.Noop(TableDefOperationMeta(existingRemoteTable, local))
-                else
-                  UpdateOperation.RecreateView(
-                    existingRemoteTable,
-                    local,
-                    createNew(local)
-                  )
-
-              case (local: BQTableDef.MaterializedView[Any], remote: BQTableDef.MaterializedView[Any]) =>
-                val reason =
-                  s"Cannot change partitioning from ${remote.partitionType} to ${local.partitionType}"
-                UpdateOperation.UnsupportedPartitioning(TableDefOperationMeta(existingRemoteTable, local), reason)
-              case (_, _) =>
-                val reason =
-                  s"cannot update a ${existingRemoteTable.getDefinition[TableDefinition].getType.name()} to ${tableDef.getClass.getSimpleName}"
-                UpdateOperation.Illegal(TableDefOperationMeta(existingRemoteTable, tableDef), reason)
-            }
-        }
-    }
-
-  private def updateTable(
-      existingRemoteTable: TableInfo,
-      local: BQTableDef.Table[Any],
-      remote: BQTableDef.Table[Any]) = {
-    // unpack values from `localTableDef`. This will break compilation we add more fields, reminding us to update here
-    val BQTableDef.Table(
-      _,
-      schema,
-      partitioning,
-      description,
-      clustering,
-      labels,
-      tableOptions
-    ) = local
-
-    existingRemoteTable.toBuilder
-      .setDefinition {
-        StandardTableDefinition.newBuilder
-          .setSchema(SchemaHelper.toSchema(schema))
-          .setTimePartitioning(
-            PartitionTypeHelper.timePartitioned(partitioning, tableOptions).orNull
-          )
-          .setRangePartitioning(
-            PartitionTypeHelper.rangepartitioned(partitioning).orNull
-          )
-          .setClustering(clusteringFrom(clustering).orNull)
-          .build()
-      }
-      .setRequirePartitionFilter(
-        // Override partitionFilterRequired flag if the table is not partitioned.
-        partitioning match {
-          case BQPartitionType.DatePartitioned(_) => tableOptions.partitionFilterRequired
-          case BQPartitionType.MonthPartitioned(_) => tableOptions.partitionFilterRequired
-          case _ => null
-        }
-      )
-      .setDescription(description.orNull)
-      .setLabels(labels.forUpdate(Some(remote)))
-      .build()
-  }
-
-  def createNew(localTableDef: BQTableDef[Any]): UpdateOperation.CreateTable =
-    localTableDef match {
-      // Views must first be created without schema, then updated with schema. (2021-01-13)
-      case BQTableDef.View(tableId, _, query, schema, description, labels) =>
-        val withoutSchema: TableInfo =
-          newTable(
-            tableId.underlying,
-            ViewDefinition.of(query.asStringWithUDFs),
-            TableOptions.Empty,
-            description,
-            labels
-          )
-
-        val withSchema: TableInfo =
-          withoutSchema.toBuilder
-            .setDefinition(
-              withoutSchema
-                .getDefinition[ViewDefinition]
-                .toBuilder
-                .setSchema(SchemaHelper.toSchema(schema))
-                .build()
+          case (local: BQTableDef.Table[Any], remote: BQTableDef.Table[Any]) =>
+            UpdateOperation.UnsupportedPartitioning(
+              TableDefOperationMeta(remote, local),
+              s"Cannot change partitioning from ${remote.partitionType} to ${local.partitionType}"
             )
-            .build()
+          case (local: BQTableDef.View[Any], remote: BQTableDef.View[Any]) =>
+            if (local === remote.withTableType(local.partitionType))
+              UpdateOperation.Noop(TableDefOperationMeta(remote, local))
+            else
+              UpdateOperation.RecreateView(
+                existingDef,
+                local,
+                UpdateOperation.CreateTable(local.copy(schema = BQSchema.of()), Some(local)))
 
-        UpdateOperation.CreateTable(localTableDef, withoutSchema, Some(withSchema))
+          case (local: BQTableDef.MaterializedView[Any], remote: BQTableDef.MaterializedView[Any])
+              if local.partitionType === remote.partitionType =>
+            def outline(field: BQField): BQField =
+              field.copy(
+                mode = BQField.Mode.NULLABLE,
+                description = None,
+                subFields = field.subFields.map(outline)
+              )
 
-      case BQTableDef.Table(
-            tableId,
-            schema,
-            partitionType,
-            description,
-            clustering,
-            labels,
-            tableOptions
-          ) =>
-        val toCreate: TableInfo =
-          newTable(
-            tableId.underlying,
-            StandardTableDefinition.newBuilder
-              .setSchema(SchemaHelper.toSchema(schema))
-              .setTimePartitioning(PartitionTypeHelper.timePartitioned(partitionType, tableOptions).orNull)
-              .setRangePartitioning(PartitionTypeHelper.rangepartitioned(partitionType).orNull)
-              .setClustering(clusteringFrom(clustering).orNull)
-              .build,
-            tableOptions,
-            description,
-            labels
-          )
-        UpdateOperation.CreateTable(localTableDef, toCreate, None)
+            val patchedLocalMVDef =
+              local.copy(
+                // Materialized views are given a schema, but we cant affect it in any way.
+                schema = BQSchema(local.schema.fields.map(outline)),
+                // Override partitionFilterRequired flag if the view is not partitioned.
+                tableOptions = local.partitionType match {
+                  case BQPartitionType.DatePartitioned(_) => local.tableOptions
+                  case BQPartitionType.MonthPartitioned(_) => local.tableOptions
+                  case _ => local.tableOptions.copy(partitionFilterRequired = false)
+                }
+              )
 
-      case BQTableDef.MaterializedView(
-            tableId,
-            partitionType,
-            query,
-            schema @ _,
-            enableRefresh,
-            refreshIntervalMs,
-            description,
-            labels,
-            tableOptions
-          ) =>
-        val toCreate: TableInfo =
-          newTable(
-            tableId.underlying,
-            MaterializedViewDefinition
-              .newBuilder(query.asStringWithUDFs)
-              .setEnableRefresh(enableRefresh)
-              // .setSchema(schema.toSchema)  // not possible for now
-              .setRefreshIntervalMs(refreshIntervalMs)
-              .setTimePartitioning(PartitionTypeHelper.timePartitioned(partitionType, tableOptions).orNull)
-              .setRangePartitioning(PartitionTypeHelper.rangepartitioned(partitionType).orNull)
-              .build(),
-            tableOptions,
-            description,
-            labels
-          )
+            if (patchedLocalMVDef === remote)
+              UpdateOperation.Noop(TableDefOperationMeta(remote, local))
+            else
+              UpdateOperation.RecreateView(
+                existingDef,
+                local,
+                UpdateOperation.CreateTable(local.copy(schema = BQSchema.of()), Some(patchedLocalMVDef))
+              )
 
-        UpdateOperation.CreateTable(localTableDef, toCreate, None)
-    }
-
-  private def newTable(
-      tableId: TableId,
-      definition: TableDefinition,
-      tableOptions: TableOptions,
-      description: Option[String],
-      labels: TableLabels
-  ): TableInfo = {
-    val builder = TableInfo
-      .newBuilder(tableId, definition)
-      .setDescription(description.orNull)
-      .setLabels(labels.forUpdate(maybeExistingTable = None))
-
-    // For some reason requirePartitionFilter = false <> requirePartitionFilter = null
-    if (tableOptions.partitionFilterRequired) {
-      builder.setRequirePartitionFilter(tableOptions.partitionFilterRequired).build()
-    } else {
-      builder.build()
-    }
-  }
-
-  private def clusteringFrom(clustering: List[Ident]): Option[Clustering] =
-    clustering match {
-      case Nil => None
-      case nonEmpty =>
-        Some(
-          Clustering
-            .newBuilder()
-            .setFields(nonEmpty.map(_.value).asJava)
-            .build()
-        )
+          case (local: BQTableDef.MaterializedView[Any], remote: BQTableDef.MaterializedView[Any]) =>
+            val reason =
+              s"Cannot change partitioning from ${remote.partitionType} to ${local.partitionType}"
+            UpdateOperation.UnsupportedPartitioning(TableDefOperationMeta(remote, local), reason)
+          case (_, _) =>
+            val reason =
+              s"cannot update a ${existingDef.getClass.getSimpleName} to ${tableDef.getClass.getSimpleName}"
+            UpdateOperation.Illegal(TableDefOperationMeta(existingDef.our, tableDef), reason)
+        }
     }
 }


### PR DESCRIPTION
We should only consider our types when determining update operations

Extract RoutineHelper
Extract TableHelper

Partially backported from https://github.com/nrkno/bigquery-scala/pull/255
Depends on https://github.com/nrkno/bigquery-scala/pull/274