### PR TITLE
Drop JSON null values on streams

### DIFF
--- a/core/src/main/scala/no/nrk/bigquery/util/StreamUtils.scala
+++ b/core/src/main/scala/no/nrk/bigquery/util/StreamUtils.scala
@@ -23,7 +23,7 @@ object StreamUtils {
   def toLineSeparatedJsonBytes[F[_]: Sync, A: Encoder](
       chunkSize: Int
   ): Pipe[F, A, Chunk[Byte]] =
-    _.map(_.asJson.noSpaces)
+    _.map(_.asJson.dropNullValues.noSpaces)
       .intersperse("\n")
       .through(fs2.text.utf8.encode)
       .through(Compression.forSync[F].gzip())


### PR DESCRIPTION
When sending data with `loadJson`, empty `Option` properties are sent as JSON `null`. While BigQuery then stores it as a column `null` for almost all column types, it is not the case with JSON column types.

For example:
- load with `None` => stored as JSON `null` (not column `null`)
- pull => returns `Some(null)`

The change is simple: just remove the `null` JSON properties so that BigQuery *always* stores a DB `null`, even with the JSON column type.