### PR TITLE
feat: return list of referenced tables in QueryStats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.tools.mima.core.*
 
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.19" // your current series x.y
+ThisBuild / tlBaseVersion := "0.20" // your current series x.y
 
 ThisBuild / organization := "no.nrk.bigquery"
 ThisBuild / organizationName := "NRK"

--- a/core/src/main/scala/no/nrk/bigquery/BQJobStatistics.scala
+++ b/core/src/main/scala/no/nrk/bigquery/BQJobStatistics.scala
@@ -35,7 +35,8 @@ object BQJobStatistics {
       totalBytesBilled: Option[Long],
       totalBytesProcessed: Option[Long],
       totalPartitionsProcessed: Option[Long],
-      totalSlotMs: Option[Long]
+      totalSlotMs: Option[Long],
+      referencedTables: Option[List[BQTableId]]
   ) extends BQJobStatistics
 
   final case class Load(

--- a/google-client/src/main/scala/no/nrk/bigquery/client/google/internal/GoogleTypeHelper.scala
+++ b/google-client/src/main/scala/no/nrk/bigquery/client/google/internal/GoogleTypeHelper.scala
@@ -101,7 +101,10 @@ object GoogleTypeHelper {
       Option(statistics.getTotalBytesBilled).map(_.longValue()),
       Option(statistics.getTotalBytesProcessed).map(_.longValue()),
       Option(statistics.getTotalPartitionsProcessed).map(_.longValue()),
-      Option(statistics.getTotalSlotMs).map(_.longValue())
+      Option(statistics.getTotalSlotMs).map(_.longValue()),
+      Option(statistics.getReferencedTables).map(
+        _.asScala.toList
+          .map(t => BQTableId(BQDataset(ProjectId(t.getProject), t.getDataset, jobId.locationId).toRef, t.getTable)))
     )
 
   def toLoadStats(jobId: BQJobId, statistics: JobStatistics.LoadStatistics) =

--- a/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/JobHelper.scala
+++ b/http4s-client/src/main/scala/no/nrk/bigquery/client/http4s/internal/JobHelper.scala
@@ -42,7 +42,13 @@ object JobHelper {
         qstat.totalBytesBilled,
         qstat.totalBytesProcessed,
         qstat.totalPartitionsProcessed,
-        qstat.totalSlotMs.map(_.toMillis)
+        qstat.totalSlotMs.map(_.toMillis),
+        qstat.referencedTables.map(_.flatMap(t =>
+          for {
+            projectId <- t.projectId
+            datasetId <- t.datasetId
+            tableId <- t.tableId
+          } yield BQTableId(BQDataset(ProjectId(projectId), datasetId, jobId.locationId).toRef, tableId)))
       ))
 
   def toLoadStats(jobId: BQJobId, stat: JobStatistics) =


### PR DESCRIPTION
We would like to know what tables are referenced in a heavy query, specifically slow queries that hit a lot of views. This allows us to:

1.  dry-run a query at no cost
2. get the referenced tables
3. check if those tables have been updated recently
4. run the query for real (or not)

This information is already available in the Google BQ job statistics, so we add them in `BQJobStatistics.Query` here.

An alternative would possibly be to expose the underlying Java `JobStatistics` object so we can pick it out from there.