### PR TITLE
fix comparison bug for udf's

### DIFF
--- a/core/src/main/scala/no/nrk/bigquery/internal/RoutineUpdateOperation.scala
+++ b/core/src/main/scala/no/nrk/bigquery/internal/RoutineUpdateOperation.scala
@@ -10,11 +10,21 @@ package internal
 import cats.Eq
 
 object RoutineUpdateOperation {
+
+  private def normalizeType(tpe: BQType): BQType =
+    tpe.copy(
+      mode = BQField.Mode.REQUIRED,
+      subFields = tpe.subFields.map { case (name, t) => (name, normalizeType(t)) }
+    )
+
+  private def normalizeParam(p: BQRoutine.Param): BQRoutine.Param =
+    p.copy(maybeType = p.maybeType.map(normalizeType))
+
   implicit val eqUDF: Eq[UDF.Persistent[?]] = Eq.instance { (a, b) =>
     a.name == b.name &&
-    a.params == b.params &&
+    a.params.unsized.map(normalizeParam) == b.params.unsized.map(normalizeParam) &&
     a.body.asFragment.asString == b.body.asFragment.asString &&
-    a.returnType == b.returnType
+    a.returnType.map(normalizeType) == b.returnType.map(normalizeType)
   }
 
   implicit val eqTVF: Eq[TVF[?, ?]] = Eq.instance { (a, b) =>

--- a/google-client/src/main/scala/no/nrk/bigquery/client/google/internal/RoutineHelper.scala
+++ b/google-client/src/main/scala/no/nrk/bigquery/client/google/internal/RoutineHelper.scala
@@ -118,7 +118,7 @@ object RoutineHelper {
       case s: Body.Sql =>
         baseBuilder
           .setLanguage("SQL")
-          .setBody(s.asFragment.asString)
+          .setBody(s.body.asString)
           .setImportedLibraries(List.empty.asJava)
       case Body.Js(javascriptSnippet, gsLibraryPath) =>
         baseBuilder

--- a/google-client/src/test/scala/no/nrk/bigquery/client/google/internal/RoutineHelperTest.scala
+++ b/google-client/src/test/scala/no/nrk/bigquery/client/google/internal/RoutineHelperTest.scala
@@ -76,13 +76,52 @@ class RoutineUpdateOperationTest extends FunSuite {
       .newBuilder(routineId)
       .setRoutineType("SCALAR_FUNCTION")
       .setLanguage("SQL")
-      .setBody("((1))")
+      .setBody("(1)")
       .setReturnType(StandardSQLDataType.newBuilder().setTypeKind(BQType.INT64.tpe.name).build())
       .build()
 
     RoutineUpdateOperation.from(udf, Some(ExistingRoutine(udf, routine))) match {
       case _: UpdateOperation.Noop =>
       case other => fail(other.toString)
+    }
+  }
+
+  test("noop udf round-trip through toGoogle/fromGoogle") {
+    val rtUdf: UDF.Persistent[_0] =
+      UDF.persistent(
+        ident"foo",
+        BQDataset.Ref(ProjectId("test-project-123456"), "ds1"),
+        Params.empty,
+        UDF.Body.Sql(bqfr"(1)"),
+        Some(BQType.INT64),
+        None
+      )
+    val googleRoutine = RoutineHelper.toGoogle(rtUdf, None)
+    val roundTripped = RoutineHelper.fromGoogle(googleRoutine)
+
+    RoutineUpdateOperation.from(rtUdf, Some(ExistingRoutine(roundTripped, googleRoutine))) match {
+      case _: UpdateOperation.Noop =>
+      case other => fail(s"expected Noop after round-trip, got: $other")
+    }
+  }
+
+  test("noop udf round-trip with struct return type") {
+    val structUdf: UDF.Persistent[_1] =
+      UDF.persistent(
+        ident"bar",
+        BQDataset.Ref(ProjectId("test-project-123456"), "ds1"),
+        Params(Param("input", BQType.STRING)),
+        UDF.Body.Sql(bqfr"(SELECT STRUCT(input AS name, 1 AS count))"),
+        Some(BQType.struct(("name", BQType.STRING), ("count", BQType.INT64))),
+        Some("a test udf")
+      )
+
+    val googleRoutine = RoutineHelper.toGoogle(structUdf, None)
+    val roundTripped = RoutineHelper.fromGoogle(googleRoutine)
+
+    RoutineUpdateOperation.from(structUdf, Some(ExistingRoutine(roundTripped, googleRoutine))) match {
+      case _: UpdateOperation.Noop =>
+      case other => fail(s"expected Noop after round-trip, got: $other")
     }
   }
 


### PR DESCRIPTION
**To bugger:**

1) Det er mismatch mellom `BQType.Mode` i UDFene fetchet fra BQ, og det vi har i vår repo. Det som skjer er at i `datahub` repo har UDF parametere og return types `BQType` med `BQField.Mode.REQUIRED` (E.g.: `BQType(BQField.Mode.Required, BQField.Type.BOOL, Nil)`), mens infoen om UDFer man får fra bigquery ikke har noen `Mode` i seg i det heletatt. Det man får fra BQ er bare navn og type. `bigquery-scala` gjør så om det vi får fra BQ til BQFields, men da med `BQType.Mode.NULLABLE`. 

2) Når vi gjør om UDFene våres til formatet som brukes når vi pusher dem opp til BQ, så wrappes (i `bigquery-scala`) UDF sql bodyen med en ekstra parantes. Når BQCompareToProd sammenligner SQL Bodyen i det vi har i vår repo, med det som er på BQ, så er det altid mismatch på grunn av den ekstra parantesen. 

**Hvordan fikse:**

1) jeg har lagt til to mulige fixes, og vi kan velge en av dem (se file changes). Den ene endrer default verdien for UDFer fra BQ fra Mode.NULLABLE til Mode.REQUIRED, som motsvarer det vi har i datahub. Den andre mulige fixen er å normalisera verdiene i den faktiske sjekken som sjekker UDFene i repoen opp mot de i BQ. Den "snilleste" endringen er kanskje å normalisere i sjekken. Men hva synes dere?

2) ta bort wrappingen når vi creater/updater UDFer i BQ. Er det noen ulempe med å gjøre dette?